### PR TITLE
fix(tour): mobile step 2 tooltip clipped by viewport edge

### DIFF
--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -38,14 +38,16 @@ function computePosition(
   const targetInBottomHalf = targetRect.top > window.innerHeight * 0.4;
   const insufficientSpaceBelow = spaceBelow < 200;
   if (targetTooTall || (targetInBottomHalf && insufficientSpaceBelow)) {
+    // Use explicit left instead of left:50%+translateX(-50%) because
+    // Framer Motion's animate overrides the CSS transform, breaking centering.
+    const sheetWidth = Math.min(isMobile ? tooltipWidth : 420, window.innerWidth - safeMargin * 2);
     return {
       position: "bottom",
       style: {
-        maxWidth: isMobile ? tooltipWidth : 420,
+        width: sheetWidth,
+        maxWidth: sheetWidth,
         bottom: safeMargin,
-        left: "50%",
-        transform: "translateX(-50%)",
-        width: `calc(100% - ${safeMargin * 2}px)`,
+        left: (window.innerWidth - sheetWidth) / 2,
         maxHeight: `calc(50vh - ${safeMargin}px)`,
       },
     };


### PR DESCRIPTION
## Summary
- Tooltip do passo 2 do tour guiado (Pesquise Monstros) estava cortado no mobile — metade ficava fora da tela
- Causa: Framer Motion sobrescrevia o `transform: translateX(-50%)` usado para centralizar o bottom-sheet, empurrando o tooltip para a direita
- Fix: usar `left` em pixels calculados ao invés de depender de CSS transform

## Test plan
- [ ] Abrir `/try` no celular (ou DevTools 375x667)
- [ ] Avançar até o passo 2/10 (Pesquise Monstros)
- [ ] Tooltip deve estar centralizado na parte inferior da tela, sem cortar texto
- [ ] Navegar por todos os 10 passos do tour sem quebra visual

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd