### PR TITLE
fix(tour): auto-click goblin on step 3→4 transition

### DIFF
--- a/components/tour/TourProvider.tsx
+++ b/components/tour/TourProvider.tsx
@@ -198,9 +198,9 @@ export function TourProvider() {
       return () => clearTimeout(timer);
     }
 
-    // Auto-click the first Goblin result when entering the monster-result step
-    // This adds the goblin to combat via the real UI flow (closes search, updates list)
-    if (step.id === "monster-result") {
+    // Auto-click the first Goblin result when entering the import-hint step
+    // (user clicked "Next" on step 3 → step 4 transition)
+    if (step.id === "import-hint") {
       const timer = setTimeout(() => {
         const firstResult = document.querySelector<HTMLButtonElement>(
           '[data-tour-id="monster-result"] button'


### PR DESCRIPTION
## Summary
- Auto-click do primeiro Goblin agora acontece quando o usuário clica "Próximo" no passo 3 (transição 3→4)
- Passo 3 mostra tooltip "Adicione ao Combate", usuário lê e clica Próximo
- Ao entrar no passo 4, o Goblin é clicado automaticamente via UI real

## Test plan
- [ ] Abrir `/try` no celular
- [ ] Passo 3: tooltip "Adicione ao Combate" aparece, Goblin NÃO é clicado ainda
- [ ] Clicar "Próximo" → Goblin é selecionado automaticamente
- [ ] Completar tour sem erros

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd