### PR TITLE
fix(tour): move auto-search to step 2→3 transition

### DIFF
--- a/components/tour/TourProvider.tsx
+++ b/components/tour/TourProvider.tsx
@@ -178,8 +178,9 @@ export function TourProvider() {
 
     const step = effectiveSteps[currentStep];
 
-    // Auto-search "goblin" when entering the monster-search step
-    if (step.id === "monster-search") {
+    // Auto-search "goblin" when entering the monster-result step (transition 2→3)
+    // so results are visible when the "Adicione ao Combate" tooltip appears
+    if (step.id === "monster-result") {
       const timer = setTimeout(() => {
         const input = document.querySelector<HTMLInputElement>(
           '[data-tour-id="monster-search"] input[type="text"]'


### PR DESCRIPTION
## Summary
- Auto-search "goblin" movido do passo 2 para o passo 3 (transição 2→3)
- Agora: Passo 2 mostra painel de busca vazio → Passo 3 digita "goblin" e mostra resultados com tooltip "Adicione ao Combate" → Passo 4 clica o primeiro Goblin

## Test plan
- [ ] Passo 2: painel de busca sem resultados
- [ ] Clicar Próximo → Passo 3: "goblin" é digitado, resultados aparecem com tooltip
- [ ] Clicar Próximo → Passo 4: Goblin é clicado automaticamente

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd