### PR TITLE
feat(tour): add monster-added step to initiative list

### DIFF
--- a/components/guest/GuestCombatClient.tsx
+++ b/components/guest/GuestCombatClient.tsx
@@ -431,7 +431,7 @@ function GuestEncounterSetup({ onStartCombat, onShareUpsell }: { onStartCombat: 
       </div>
 
       {/* Combatant list */}
-      <div className="space-y-1" data-testid="setup-combatant-list" role="list" aria-label="Combatants">
+      <div className="space-y-1" data-testid="setup-combatant-list" data-tour-id="combatant-list" role="list" aria-label="Combatants">
         <SortableCombatantList
           combatants={combatants}
           onReorder={reorderCombatants}

--- a/components/tour/TourProvider.tsx
+++ b/components/tour/TourProvider.tsx
@@ -199,9 +199,9 @@ export function TourProvider() {
       return () => clearTimeout(timer);
     }
 
-    // Auto-click the first Goblin result when entering the import-hint step
+    // Auto-click the first Goblin result when entering the monster-added step
     // (user clicked "Next" on step 3 → step 4 transition)
-    if (step.id === "import-hint") {
+    if (step.id === "monster-added") {
       const timer = setTimeout(() => {
         const firstResult = document.querySelector<HTMLButtonElement>(
           '[data-tour-id="monster-result"] button'

--- a/components/tour/TourProvider.tsx
+++ b/components/tour/TourProvider.tsx
@@ -178,8 +178,9 @@ export function TourProvider() {
 
     const step = effectiveSteps[currentStep];
 
-    // Auto-search "goblin" when entering the monster-search step
-    if (step.id === "monster-search") {
+    // Auto-search "goblin" when entering the monster-result step (transition 2→3)
+    // so results are visible when the "Adicione ao Combate" tooltip appears
+    if (step.id === "monster-result") {
       const timer = setTimeout(() => {
         const input = document.querySelector<HTMLInputElement>(
           '[data-tour-id="monster-search"] input[type="text"]'

--- a/components/tour/tour-steps.ts
+++ b/components/tour/tour-steps.ts
@@ -51,7 +51,17 @@ export const TOUR_STEPS: TourStepConfig[] = [
     position: "bottom",
     phase: "setup",
   },
-  // Step 3 — Import Hint (info)
+  // Step 3 — Monster Added confirmation (info)
+  {
+    id: "monster-added",
+    targetSelector: '[data-tour-id="combatant-list"]',
+    titleKey: "tour.monster_added_title",
+    descriptionKey: "tour.monster_added_description",
+    type: "info",
+    position: "top",
+    phase: "setup",
+  },
+  // Step 4 — Import Hint (info)
   {
     id: "import-hint",
     targetSelector: '[data-tour-id="import-content"]',

--- a/messages/en.json
+++ b/messages/en.json
@@ -1344,6 +1344,8 @@
     "search_description": "Use this field to search for D&D monsters by name. Try typing 'Goblin'!",
     "add_monster_title": "Add to Combat",
     "add_monster_description": "Click on a monster from the list to add it to the combat.",
+    "monster_added_title": "Monster Added!",
+    "monster_added_description": "The Goblin has joined the initiative list. All combatants appear here with HP, AC, and initiative.",
     "manual_add_title": "Manual Entry",
     "manual_add_description": "You can also manually add players or custom NPCs using this row.",
     "initiative_title": "Initiative & Turn Order",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1344,6 +1344,8 @@
     "search_description": "Use este campo para buscar monstros do D&D pelo nome. Experimente digitar 'Goblin'!",
     "add_monster_title": "Adicione ao Combate",
     "add_monster_description": "Clique em um monstro da lista para adicioná-lo ao combate.",
+    "monster_added_title": "Monstro Adicionado!",
+    "monster_added_description": "O Goblin entrou na lista de iniciativa do combate. Todos os combatentes aparecem aqui com HP, CA e iniciativa.",
     "manual_add_title": "Adição Manual",
     "manual_add_description": "Você também pode adicionar jogadores ou NPCs personalizados manualmente nesta linha.",
     "initiative_title": "Iniciativa e Ordem de Turno",


### PR DESCRIPTION
## Summary
- Novo passo no tour entre "Adicione ao Combate" e "Import Hint"
- Após auto-click do Goblin, destaca a lista de combatentes mostrando que ele entrou na iniciativa
- Tooltip: "Monstro Adicionado! O Goblin entrou na lista de iniciativa do combate."

## Test plan
- [ ] Passo 3: mostra resultados de busca com tooltip "Adicione ao Combate"
- [ ] Clicar Próximo → Goblin é clicado automaticamente
- [ ] Novo passo 4: spotlight na lista de combatentes com "Monstro Adicionado!"
- [ ] Próximo → continua normalmente para Import Hint

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd