### PR TITLE
fix(tour): restore missing spaceBelow variable

### DIFF
--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -31,6 +31,7 @@ function computePosition(
 
   // Bottom-sheet fallback: only when target is too tall (>50% viewport).
   // For small targets near the bottom, the regular top/bottom logic handles it.
+  const spaceBelow = window.innerHeight - targetRect.bottom;
   const targetTooTall = targetRect.height > window.innerHeight * 0.5;
   if (targetTooTall) {
     // Use explicit left instead of left:50%+translateX(-50%) because


### PR DESCRIPTION
## Summary
- `spaceBelow` foi removido acidentalmente no PR anterior junto com as condições do bottom-sheet
- Sem ele, o loop de posicionamento nunca conseguia avaliar a posição "bottom", causando fallback errado
- Tooltip dos passos 6/7 agora posiciona corretamente acima do target

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd