### PR TITLE
fix(tour): more gap for top-positioned tooltip on mobile

### DIFF
--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -84,7 +84,8 @@ function computePosition(
       break;
     }
     case "top": {
-      const bottomVal = window.innerHeight - targetRect.top + padding;
+      const topPadding = isMobile ? 24 : padding;
+      const bottomVal = window.innerHeight - targetRect.top + topPadding;
       style.bottom = bottomVal;
       style.left = Math.max(safeMargin, Math.min(centerX - tooltipWidth / 2, window.innerWidth - tooltipWidth - safeMargin));
       style.maxHeight = `${window.innerHeight - bottomVal - safeMargin}px`;


### PR DESCRIPTION
## Summary
- Tooltip top-positioned no mobile agora tem 24px de gap (era 12px)
- Mais espaço entre tooltip e target nos passos 6-8

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd