### PR TITLE
fix(tour): wider tooltip + compact dots on mobile

### DIFF
--- a/components/tour/TourProgress.tsx
+++ b/components/tour/TourProgress.tsx
@@ -6,21 +6,24 @@ interface TourProgressProps {
 }
 
 export function TourProgress({ currentStep, totalSteps }: TourProgressProps) {
+  const compact = totalSteps > 8;
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs text-muted-foreground/60 font-mono tabular-nums">
+    <div className="flex items-center gap-1.5">
+      <span className="text-[10px] text-muted-foreground/60 font-mono tabular-nums">
         {currentStep + 1}/{totalSteps}
       </span>
-      <div className="flex items-center gap-1" aria-label={`Step ${currentStep + 1} of ${totalSteps}`}>
+      <div className={`flex items-center ${compact ? "gap-0.5" : "gap-1"}`} aria-label={`Step ${currentStep + 1} of ${totalSteps}`}>
         {Array.from({ length: totalSteps }, (_, i) => (
           <div
             key={i}
-            className={`h-1 rounded-full transition-all duration-200 ${
+            className={`rounded-full transition-all duration-200 ${
+              compact ? "h-0.5" : "h-1"
+            } ${
               i === currentStep
-                ? "w-3 bg-gold"
+                ? `${compact ? "w-2" : "w-3"} bg-gold`
                 : i < currentStep
-                  ? "w-1.5 bg-gold/40"
-                  : "w-1.5 bg-white/20"
+                  ? `${compact ? "w-1" : "w-1.5"} bg-gold/40`
+                  : `${compact ? "w-1" : "w-1.5"} bg-white/20`
             }`}
           />
         ))}

--- a/components/tour/TourTooltip.tsx
+++ b/components/tour/TourTooltip.tsx
@@ -25,8 +25,8 @@ function computePosition(
   preferred: Position | undefined
 ): { position: Position; style: React.CSSProperties } {
   const padding = 12;
-  const tooltipWidth = Math.min(340, window.innerWidth - 32);
   const isMobile = window.innerWidth < 768;
+  const tooltipWidth = isMobile ? window.innerWidth - 24 : Math.min(340, window.innerWidth - 32);
   const safeMargin = 16;
 
   // Bottom-sheet fallback: only when target is too tall (>50% viewport).


### PR DESCRIPTION
## Summary
- Tooltip mobile usa largura total da viewport menos 24px (era limitado a 340px)
- Progress dots ficam compactos (menores + menos gap) quando tour tem >8 steps
- Botões "Voltar" e "Próximo" não ficam mais cortados

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd