### PR TITLE
feat: prefetch SRD data on LP after idle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { AnimatedCounter } from "@/components/marketing/AnimatedCounter";
 import { HeroParticles } from "@/components/marketing/HeroParticles";
 import { LandingPageTracker } from "@/components/analytics/LandingPageTracker";
 import { LpPricingSection } from "@/components/marketing/LpPricingSection";
+import { SrdPrefetch } from "@/components/srd/SrdPrefetch";
 import { Button } from "@/components/ui/button";
 import { RuneCircle, QuestPath, TorchGlow, FireTrail } from "@/components/ui/rpg";
 import { getFireStepColor } from "@/lib/design/rpg-tokens";
@@ -931,6 +932,7 @@ export default function LandingPage() {
       <FinalCtaSection />
 
       <LandingPageTracker />
+      <SrdPrefetch />
       <Footer />
     </div>
   );

--- a/components/srd/SrdPrefetch.tsx
+++ b/components/srd/SrdPrefetch.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Prefetches SRD JSON files after the page is idle.
+ * Uses requestIdleCallback so it never blocks the main thread or delays LP render.
+ * Priority order: monsters-2014 (default ruleset) first, then smaller files.
+ */
+
+const SRD_FILES = [
+  "/srd/monsters-2014.json",
+  "/srd/conditions.json",
+  "/srd/spells-2014.json",
+  "/srd/monsters-2024.json",
+  "/srd/spells-2024.json",
+  "/srd/items.json",
+];
+
+function prefetchFiles() {
+  for (const href of SRD_FILES) {
+    const link = document.createElement("link");
+    link.rel = "prefetch";
+    link.as = "fetch";
+    link.href = href;
+    link.crossOrigin = "anonymous";
+    document.head.appendChild(link);
+  }
+}
+
+export function SrdPrefetch() {
+  useEffect(() => {
+    if (typeof requestIdleCallback !== "undefined") {
+      const id = requestIdleCallback(prefetchFiles);
+      return () => cancelIdleCallback(id);
+    }
+    // Fallback: wait 2s after mount
+    const timer = setTimeout(prefetchFiles, 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Novo componente `SrdPrefetch` na landing page que injeta `<link rel="prefetch">` para os JSONs SRD
- Usa `requestIdleCallback` — só executa quando o browser está idle, zero impacto na LP
- Ordem de prioridade: monsters-2014 (6.2M, default) → conditions (54K) → spells → monsters-2024 → items
- Quando o usuário clica "Experimentar" e vai pro /try, os dados já estão no cache HTTP

## Test plan
- [ ] LP carrega normalmente sem delay
- [ ] DevTools Network: após idle, prefetch requests aparecem com prioridade "Lowest"
- [ ] Navegar para /try: dados SRD carregam do cache (status 304 ou cache hit)

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd