### PR TITLE
feat: animated SRD loading screen on /try

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { AnimatedCounter } from "@/components/marketing/AnimatedCounter";
 import { HeroParticles } from "@/components/marketing/HeroParticles";
 import { LandingPageTracker } from "@/components/analytics/LandingPageTracker";
 import { LpPricingSection } from "@/components/marketing/LpPricingSection";
-import { SrdPrefetch } from "@/components/srd/SrdPrefetch";
+
 import { Button } from "@/components/ui/button";
 import { RuneCircle, QuestPath, TorchGlow, FireTrail } from "@/components/ui/rpg";
 import { getFireStepColor } from "@/lib/design/rpg-tokens";
@@ -932,7 +932,6 @@ export default function LandingPage() {
       <FinalCtaSection />
 
       <LandingPageTracker />
-      <SrdPrefetch />
       <Footer />
     </div>
   );

--- a/app/try/layout.tsx
+++ b/app/try/layout.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Navbar } from "@/components/layout/Navbar";
-import { SrdInitializer } from "@/components/srd/SrdInitializer";
+import { SrdLoadingScreen } from "@/components/srd/SrdLoadingScreen";
 import { FloatingCardContainer } from "@/components/oracle/FloatingCardContainer";
 import { GuestBanner } from "@/components/guest/GuestBanner";
 import { TourProvider } from "@/components/tour/TourProvider";
@@ -29,15 +29,16 @@ export default function TryLayout({ children }: { children: React.ReactNode }) {
           </>
         }
       />
-      <SrdInitializer />
-      <FloatingCardContainer />
-      <main className="flex-1 pt-[72px] isolate">
-        <GuestBanner />
-        <div className="p-6">
-          {children}
-        </div>
-        <TourProvider />
-      </main>
+      <SrdLoadingScreen>
+        <FloatingCardContainer />
+        <main className="flex-1 pt-[72px] isolate">
+          <GuestBanner />
+          <div className="p-6">
+            {children}
+          </div>
+          <TourProvider />
+        </main>
+      </SrdLoadingScreen>
     </div>
   );
 }

--- a/components/srd/SrdLoadingScreen.tsx
+++ b/components/srd/SrdLoadingScreen.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useSrdStore } from "@/lib/stores/srd-store";
+
+const LOADING_MESSAGES = [
+  "Catalogando monstros...",
+  "Reunindo ordem de iniciativa...",
+  "Amplificando poderes...",
+  "Preparando magias...",
+  "Afiando espadas...",
+  "Consultando o oráculo...",
+];
+
+const MIN_DISPLAY_MS = 1800;
+
+/**
+ * Full-screen animated loading screen that initializes SRD data.
+ * Only shows on first visit (no IndexedDB cache). Once SRD is loaded
+ * and min display time passes, fades out and reveals children.
+ */
+export function SrdLoadingScreen({ children }: { children: React.ReactNode }) {
+  const { is_loading, monsters } = useSrdStore();
+  const [showLoader, setShowLoader] = useState(true);
+  const [messageIndex, setMessageIndex] = useState(0);
+  const minTimeRef = useRef(false);
+  const srdReadyRef = useRef(false);
+
+  // Start SRD initialization
+  useEffect(() => {
+    useSrdStore.getState().initializeSrd();
+  }, []);
+
+  // Min display timer
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      minTimeRef.current = true;
+      if (srdReadyRef.current) setShowLoader(false);
+    }, MIN_DISPLAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Track SRD readiness
+  useEffect(() => {
+    if (!is_loading && monsters.length > 0) {
+      srdReadyRef.current = true;
+      if (minTimeRef.current) setShowLoader(false);
+    }
+  }, [is_loading, monsters]);
+
+  // Skip loader entirely if data is already cached (instant load)
+  useEffect(() => {
+    if (!is_loading && monsters.length > 0) {
+      setShowLoader(false);
+    }
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Cycle messages
+  useEffect(() => {
+    if (!showLoader) return;
+    const interval = setInterval(() => {
+      setMessageIndex((i) => (i + 1) % LOADING_MESSAGES.length);
+    }, 400);
+    return () => clearInterval(interval);
+  }, [showLoader]);
+
+  return (
+    <>
+      <AnimatePresence>
+        {showLoader && (
+          <motion.div
+            key="srd-loader"
+            className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-surface-primary"
+            initial={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4, ease: "easeOut" }}
+          >
+            {/* Dice spinner */}
+            <motion.div
+              className="text-5xl mb-6"
+              animate={{ rotate: [0, 360] }}
+              transition={{ duration: 1.2, repeat: Infinity, ease: "linear" }}
+            >
+              🎲
+            </motion.div>
+
+            {/* Progress bar */}
+            <div className="w-48 h-1 bg-white/10 rounded-full overflow-hidden mb-4">
+              <motion.div
+                className="h-full bg-gold rounded-full"
+                initial={{ width: "0%" }}
+                animate={{ width: "100%" }}
+                transition={{ duration: MIN_DISPLAY_MS / 1000, ease: "easeInOut" }}
+              />
+            </div>
+
+            {/* Rotating message */}
+            <AnimatePresence mode="wait">
+              <motion.p
+                key={messageIndex}
+                className="text-sm text-muted-foreground/70 font-medium"
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                transition={{ duration: 0.2 }}
+              >
+                {LOADING_MESSAGES[messageIndex]}
+              </motion.p>
+            </AnimatePresence>
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Remove prefetch de SRD da landing page (deixava LP pesada)
- Tela de loading animada no `/try` com mensagens temáticas D&D
- Só aparece na primeira visita (sem cache IndexedDB). Visitas subsequentes: skip instantâneo
- Mín 1.8s de exibição, fade out quando SRD carrega

## Mensagens rotativas
- "Catalogando monstros..."
- "Reunindo ordem de iniciativa..."
- "Amplificando poderes..."
- "Preparando magias..."
- "Afiando espadas..."
- "Consultando o oráculo..."

## Test plan
- [ ] LP não faz mais prefetch (verificar Network tab)
- [ ] /try primeira visita: tela de loading com dado girando + barra + mensagens
- [ ] /try visita com cache: skip direto para o combate
- [ ] Loading dura ~1.8s e faz fade out suave

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd