### PR TITLE
fix: clarify anti-metagame hint about dual monster names

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -3,7 +3,7 @@ title: 'Polimento Onboarding Mobile + Confirmação Limpar Tudo'
 slug: 'onboarding-mobile-polish-clear-confirm'
 created: '2026-03-29'
 status: 'in-progress'
-stepsCompleted: [1]
+stepsCompleted: [1, 2]
 tech_stack: ['Next.js', 'React 19', 'Zustand', 'next-intl', 'Tailwind CSS', 'Framer Motion']
 files_to_modify:
   - 'components/srd/SrdLoadingScreen.tsx'
@@ -13,6 +13,7 @@ files_to_modify:
   - 'components/guest/GuestCombatClient.tsx'
   - 'messages/pt-BR.json'
   - 'messages/en.json'
+  - 'lib/utils/role-config.ts'
 code_patterns: ['Zustand stores', 'next-intl useTranslations', 'Tailwind responsive md:', 'Framer Motion', 'data-tour-id selectors']
 test_patterns: ['Jest + React Testing Library']
 ---
@@ -94,6 +95,7 @@ Corrigir todos os 7 itens com mudanças cirúrgicas nos componentes existentes, 
 - **Reordenação de steps**: Mover "add-row" (step 5) para antes de "import-hint" (step 4) no array `TOUR_STEPS`. Ajustar comments dos steps.
 - **Anti-metagame hint**: Adicionar parágrafo extra no step `monster-added` (passo 4) via nova key i18n `tour.monster_added_antimetagame`. Renderizar em cor dourada abaixo da descrição principal.
 - **Focus ring do skip button**: Adicionar `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-muted-foreground/30` para evitar glow dourado herdado.
+- **Extrair ROLE_CONFIG**: Mover `ROLE_CONFIG` de `CombatantSetupRow.tsx` para `lib/utils/role-config.ts` para reutilizar em `GuestCombatClient.tsx` sem duplicação.
 
 ## Implementation Plan
 

--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -3,7 +3,7 @@ title: 'Polimento Onboarding Mobile + Confirmação Limpar Tudo'
 slug: 'onboarding-mobile-polish-clear-confirm'
 created: '2026-03-29'
 status: 'in-progress'
-stepsCompleted: [1, 2]
+stepsCompleted: [1]
 tech_stack: ['Next.js', 'React 19', 'Zustand', 'next-intl', 'Tailwind CSS', 'Framer Motion']
 files_to_modify:
   - 'components/srd/SrdLoadingScreen.tsx'
@@ -13,7 +13,6 @@ files_to_modify:
   - 'components/guest/GuestCombatClient.tsx'
   - 'messages/pt-BR.json'
   - 'messages/en.json'
-  - 'lib/utils/role-config.ts'
 code_patterns: ['Zustand stores', 'next-intl useTranslations', 'Tailwind responsive md:', 'Framer Motion', 'data-tour-id selectors']
 test_patterns: ['Jest + React Testing Library']
 ---
@@ -95,7 +94,6 @@ Corrigir todos os 7 itens com mudanças cirúrgicas nos componentes existentes, 
 - **Reordenação de steps**: Mover "add-row" (step 5) para antes de "import-hint" (step 4) no array `TOUR_STEPS`. Ajustar comments dos steps.
 - **Anti-metagame hint**: Adicionar parágrafo extra no step `monster-added` (passo 4) via nova key i18n `tour.monster_added_antimetagame`. Renderizar em cor dourada abaixo da descrição principal.
 - **Focus ring do skip button**: Adicionar `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-muted-foreground/30` para evitar glow dourado herdado.
-- **Extrair ROLE_CONFIG**: Mover `ROLE_CONFIG` de `CombatantSetupRow.tsx` para `lib/utils/role-config.ts` para reutilizar em `GuestCombatClient.tsx` sem duplicação.
 
 ## Implementation Plan
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1361,7 +1361,7 @@
     "add_monster_description": "Click on a monster from the list to add it to the combat.",
     "monster_added_title": "Monster Added!",
     "monster_added_description": "The Goblin has joined the initiative list. All combatants appear here with HP, AC, and initiative.",
-    "monster_added_antimetagame": "🛡️ Tip: tap the name or silhouette to change what players see.",
+    "monster_added_antimetagame": "🛡️ Anti-Metagame: each monster has two names — the real one (only you see) and the one visible to players. Tap the name to edit what players see.",
     "manual_add_title": "Manual Entry",
     "manual_add_description": "You can also manually add players or custom NPCs using this row.",
     "initiative_title": "Initiative & Turn Order",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1361,7 +1361,7 @@
     "add_monster_description": "Clique em um monstro da lista para adicioná-lo ao combate.",
     "monster_added_title": "Monstro Adicionado!",
     "monster_added_description": "O Goblin entrou na lista de iniciativa do combate. Todos os combatentes aparecem aqui com HP, CA e iniciativa.",
-    "monster_added_antimetagame": "🛡️ Dica: toque no nome ou na silhueta pra mudar o que os jogadores veem.",
+    "monster_added_antimetagame": "🛡️ Anti-Metagame: cada monstro tem dois nomes — o real (só você vê) e o visível para os jogadores. Toque no nome pra editar o que os jogadores veem.",
     "manual_add_title": "Adição Manual",
     "manual_add_description": "Você também pode adicionar jogadores ou NPCs personalizados manualmente nesta linha.",
     "initiative_title": "Iniciativa e Ordem de Turno",


### PR DESCRIPTION
## Summary\n\n- Rewritten anti-metagame hint in tour step 4 to explicitly explain that each monster has two names: the real one (DM only) and the display name visible to players\n- Updated both pt-BR and en translations\n\n## Test plan\n- [x] i18n keys unchanged, only values updated\n- [x] No code changes, only copy\n\nhttps://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd