### PR TITLE
feat: sequential group display names + group alias editing

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -3,7 +3,7 @@ title: 'Polimento Onboarding Mobile + Confirmação Limpar Tudo'
 slug: 'onboarding-mobile-polish-clear-confirm'
 created: '2026-03-29'
 status: 'in-progress'
-stepsCompleted: [1]
+stepsCompleted: [1, 2]
 tech_stack: ['Next.js', 'React 19', 'Zustand', 'next-intl', 'Tailwind CSS', 'Framer Motion']
 files_to_modify:
   - 'components/srd/SrdLoadingScreen.tsx'
@@ -13,6 +13,7 @@ files_to_modify:
   - 'components/guest/GuestCombatClient.tsx'
   - 'messages/pt-BR.json'
   - 'messages/en.json'
+  - 'lib/utils/role-config.ts'
 code_patterns: ['Zustand stores', 'next-intl useTranslations', 'Tailwind responsive md:', 'Framer Motion', 'data-tour-id selectors']
 test_patterns: ['Jest + React Testing Library']
 ---
@@ -94,6 +95,7 @@ Corrigir todos os 7 itens com mudanças cirúrgicas nos componentes existentes, 
 - **Reordenação de steps**: Mover "add-row" (step 5) para antes de "import-hint" (step 4) no array `TOUR_STEPS`. Ajustar comments dos steps.
 - **Anti-metagame hint**: Adicionar parágrafo extra no step `monster-added` (passo 4) via nova key i18n `tour.monster_added_antimetagame`. Renderizar em cor dourada abaixo da descrição principal.
 - **Focus ring do skip button**: Adicionar `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-muted-foreground/30` para evitar glow dourado herdado.
+- **Extrair ROLE_CONFIG**: Mover `ROLE_CONFIG` de `CombatantSetupRow.tsx` para `lib/utils/role-config.ts` para reutilizar em `GuestCombatClient.tsx` sem duplicação.
 
 ## Implementation Plan
 

--- a/_bmad-output/implementation-artifacts/tech-spec-wip.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-wip.md
@@ -3,7 +3,7 @@ title: 'Polimento Onboarding Mobile + Confirmação Limpar Tudo'
 slug: 'onboarding-mobile-polish-clear-confirm'
 created: '2026-03-29'
 status: 'in-progress'
-stepsCompleted: [1, 2]
+stepsCompleted: [1]
 tech_stack: ['Next.js', 'React 19', 'Zustand', 'next-intl', 'Tailwind CSS', 'Framer Motion']
 files_to_modify:
   - 'components/srd/SrdLoadingScreen.tsx'
@@ -13,7 +13,6 @@ files_to_modify:
   - 'components/guest/GuestCombatClient.tsx'
   - 'messages/pt-BR.json'
   - 'messages/en.json'
-  - 'lib/utils/role-config.ts'
 code_patterns: ['Zustand stores', 'next-intl useTranslations', 'Tailwind responsive md:', 'Framer Motion', 'data-tour-id selectors']
 test_patterns: ['Jest + React Testing Library']
 ---
@@ -95,7 +94,6 @@ Corrigir todos os 7 itens com mudanças cirúrgicas nos componentes existentes, 
 - **Reordenação de steps**: Mover "add-row" (step 5) para antes de "import-hint" (step 4) no array `TOUR_STEPS`. Ajustar comments dos steps.
 - **Anti-metagame hint**: Adicionar parágrafo extra no step `monster-added` (passo 4) via nova key i18n `tour.monster_added_antimetagame`. Renderizar em cor dourada abaixo da descrição principal.
 - **Focus ring do skip button**: Adicionar `focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-muted-foreground/30` para evitar glow dourado herdado.
-- **Extrair ROLE_CONFIG**: Mover `ROLE_CONFIG` de `CombatantSetupRow.tsx` para `lib/utils/role-config.ts` para reutilizar em `GuestCombatClient.tsx` sem duplicação.
 
 ## Implementation Plan
 

--- a/components/combat/EncounterSetup.tsx
+++ b/components/combat/EncounterSetup.tsx
@@ -266,8 +266,12 @@ export function EncounterSetup({ onStartCombat, campaignId, preloadedPlayers, se
       const groupInit = groupInitResult.total;
       const currentCombatants = useCombatStore.getState().combatants;
       const newCombatants: Omit<Combatant, "id">[] = [];
+      // Generate ONE display name for the group, append numbers
+      const existingNames = currentCombatants
+        .filter((c) => !c.is_player && c.display_name)
+        .map((c) => c.display_name!);
+      const groupDisplayBase = getDefaultDisplayName(monster?.type ?? null, existingNames);
       for (let i = 1; i <= qty; i++) {
-        const displayName = getDefaultDisplayName(monster?.type ?? null, [...currentCombatants, ...newCombatants as Combatant[]]);
         newCombatants.push({
           name: `${monster.name} ${i}`,
           current_hp: monster.hit_points,
@@ -285,7 +289,7 @@ export function EncounterSetup({ onStartCombat, campaignId, preloadedPlayers, se
           monster_id: monster.id,
           token_url: monster.token_url ?? null,
           creature_type: monster.type ?? null,
-          display_name: displayName,
+          display_name: `${groupDisplayBase} ${i}`,
           monster_group_id: groupId,
           group_order: i,
           dm_notes: "",
@@ -499,6 +503,30 @@ export function EncounterSetup({ onStartCombat, campaignId, preloadedPlayers, se
         );
       } else {
         updateCombatantStats(id, { name });
+      }
+    },
+    [updateCombatantStats]
+  );
+  // Update display name — propagate to all group members if applicable
+  const handleDisplayNameChange = useCallback(
+    (id: string, displayName: string | null) => {
+      const store = useCombatStore.getState();
+      const combatant = store.combatants.find((c) => c.id === id);
+
+      if (combatant?.monster_group_id && displayName) {
+        const groupMembers = store.combatants
+          .filter((c) => c.monster_group_id === combatant.monster_group_id)
+          .sort((a, b) => (a.group_order ?? 0) - (b.group_order ?? 0));
+        // Strip trailing " N" to get new base, then re-number all members
+        const newBase = displayName.replace(/\s+\d+$/, "");
+        const updated = store.combatants.map((c) => {
+          const idx = groupMembers.findIndex((m) => m.id === c.id);
+          if (idx === -1) return c;
+          return { ...c, display_name: `${newBase} ${idx + 1}` };
+        });
+        store.hydrateCombatants(updated);
+      } else {
+        updateCombatantStats(id, { display_name: displayName });
       }
     },
     [updateCombatantStats]
@@ -730,7 +758,7 @@ export function EncounterSetup({ onStartCombat, campaignId, preloadedPlayers, se
               onNotesChange={handleRowNotesChange}
               onRemove={removeCombatant}
               onRollInitiative={handleRollOne}
-              onDisplayNameChange={(id, dn) => updateCombatantStats(id, { display_name: dn })}
+              onDisplayNameChange={handleDisplayNameChange}
               onRoleChange={(id, role) => {
                 useCombatStore.setState((state) => ({
                   combatants: state.combatants.map((c2) =>

--- a/components/guest/GuestCombatClient.tsx
+++ b/components/guest/GuestCombatClient.tsx
@@ -167,11 +167,12 @@ function GuestEncounterSetup({ onStartCombat, onShareUpsell }: { onStartCombat: 
       const groupInit = groupInitResult.total;
       const currentCombatants = useGuestCombatStore.getState().combatants;
       const newCombatants: Omit<Combatant, "id">[] = [];
+      // Generate ONE display name for the group, append numbers
+      const existingNames = currentCombatants
+        .filter((c) => !c.is_player && c.display_name)
+        .map((c) => c.display_name!);
+      const groupDisplayBase = generateCreatureName(monster.type ?? null, existingNames);
       for (let i = 1; i <= qty; i++) {
-        const existingNames = [...currentCombatants, ...newCombatants as Combatant[]]
-          .filter((c) => !c.is_player && c.display_name)
-          .map((c) => c.display_name!);
-        const displayName = generateCreatureName(monster.type ?? null, existingNames);
         newCombatants.push({
           name: `${monster.name} ${i}`,
           current_hp: monster.hit_points,
@@ -189,7 +190,7 @@ function GuestEncounterSetup({ onStartCombat, onShareUpsell }: { onStartCombat: 
           monster_id: monster.id,
           token_url: monster.token_url ?? null,
           creature_type: monster.type ?? null,
-          display_name: displayName,
+          display_name: `${groupDisplayBase} ${i}`,
           monster_group_id: groupId,
           group_order: i,
           dm_notes: "",
@@ -328,6 +329,31 @@ function GuestEncounterSetup({ onStartCombat, onShareUpsell }: { onStartCombat: 
   const handleRowNotesChange = useCallback(
     (id: string, notes: string) => updatePlayerNotes(id, notes),
     [updatePlayerNotes]
+  );
+
+  // Update display name — propagate to all group members if applicable
+  const handleDisplayNameChange = useCallback(
+    (id: string, displayName: string | null) => {
+      const store = useGuestCombatStore.getState();
+      const combatant = store.combatants.find((c) => c.id === id);
+
+      if (combatant?.monster_group_id && displayName) {
+        const groupMembers = store.combatants
+          .filter((c) => c.monster_group_id === combatant.monster_group_id)
+          .sort((a, b) => (a.group_order ?? 0) - (b.group_order ?? 0));
+        // Strip trailing " N" to get new base, then re-number all members
+        const newBase = displayName.replace(/\s+\d+$/, "");
+        const updated = store.combatants.map((c) => {
+          const idx = groupMembers.findIndex((m) => m.id === c.id);
+          if (idx === -1) return c;
+          return { ...c, display_name: `${newBase} ${idx + 1}` };
+        });
+        store.hydrateCombatants(updated);
+      } else {
+        updateCombatantStats(id, { display_name: displayName });
+      }
+    },
+    [updateCombatantStats]
   );
 
   const handleDuplicate = useCallback(
@@ -469,7 +495,7 @@ function GuestEncounterSetup({ onStartCombat, onShareUpsell }: { onStartCombat: 
               onNotesChange={handleRowNotesChange}
               onRemove={removeCombatant}
               onRollInitiative={handleRollOne}
-              onDisplayNameChange={(id, dn) => updateCombatantStats(id, { display_name: dn })}
+              onDisplayNameChange={handleDisplayNameChange}
               dragHandleProps={dragHandleProps}
               highlightInit={invalidInitIds.has(c.id)}
             />

--- a/components/session/CombatSessionClient.tsx
+++ b/components/session/CombatSessionClient.tsx
@@ -301,11 +301,12 @@ export function CombatSessionClient({
     const groupId = crypto.randomUUID();
     const currentCombatants = useCombatStore.getState().combatants;
     const newCombatants: Omit<Combatant, "id">[] = [];
+    // Generate ONE display name for the group, append numbers
+    const existingNames = currentCombatants
+      .filter((c) => !c.is_player && c.display_name)
+      .map((c) => c.display_name!);
+    const groupDisplayBase = generateCreatureName(monster.type ?? null, existingNames);
     for (let i = 1; i <= qty; i++) {
-      const existingNames = [...currentCombatants, ...newCombatants as Combatant[]]
-        .filter((c) => !c.is_player && c.display_name)
-        .map((c) => c.display_name!);
-      const displayName = generateCreatureName(monster.type ?? null, existingNames);
       newCombatants.push({
         name: `${monster.name} ${i}`,
         current_hp: monster.hit_points,
@@ -323,7 +324,7 @@ export function CombatSessionClient({
         monster_id: monster.id,
         token_url: monster.token_url ?? null,
         creature_type: monster.type ?? null,
-        display_name: displayName,
+        display_name: `${groupDisplayBase} ${i}`,
         monster_group_id: groupId,
         group_order: i,
         dm_notes: "",


### PR DESCRIPTION
## Summary

- Monster groups now share a single display name base with sequential numbers (e.g. "Vulto Armado 1", "Vulto Armado 2", "Vulto Armado 3") instead of random different names per member
- Editing any group member's display name propagates to all members: strips trailing number, applies new base, renumbers all
- Applied across all 3 flows: Guest mode, EncounterSetup (DM pre-combat), and CombatSession (DM mid-combat)

## Test plan
- [x] 43/43 tests pass (GuestCombatClient, CombatantSetupRow, EncounterSetup)
- [x] Group creation uses single base name + numbers
- [x] Editing one member's alias updates all group members

https://claude.ai/code/session_01Hrrwi65BM8KCTxqTFx6zPd