### PR TITLE
feat: redesign mobile LP — reduce scroll ~64%

### DIFF
--- a/_bmad-output/planning-artifacts/ux-mobile-lp-redesign.md
+++ b/_bmad-output/planning-artifacts/ux-mobile-lp-redesign.md
@@ -1,0 +1,221 @@
+---
+status: approved
+createdDate: 2026-03-29
+author: Sally (UX Designer)
+requestedBy: Dani_
+scope: Landing Page — Mobile-only redesign
+impactOnDesktop: Nenhum. Todas as mudanças usam breakpoints Tailwind (md:/lg:). Desktop permanece inalterado.
+targetFile: app/page.tsx, components/marketing/LpPricingSection.tsx
+---
+
+# UX Spec: Redesign Mobile da Landing Page
+
+## 1. Contexto e Problema
+
+A landing page do Pocket DM foi desenhada com visual e ritmo excelentes para desktop, onde o usuário tem espaço horizontal, atenção relaxada e mouse para interações hover. No mobile, a mesma estrutura é empilhada verticalmente, resultando em **~12-15 telas de scroll** — excessivo para o contexto de uso mobile (atenção curta, polegar impaciente, geralmente chegando via link compartilhado em grupo de Discord/WhatsApp).
+
+**Perfil do visitante mobile:** Mestre de RPG que viu o link num grupo, abriu no celular entre uma atividade e outra. Tem 30-60 segundos de atenção antes de decidir se volta depois no desktop ou abandona.
+
+**Meta:** Reduzir para **~5-6 telas de scroll** no mobile mantendo os mesmos pontos de conversão e a mesma identidade visual RPG.
+
+---
+
+## 2. Inventário Atual — O que existe hoje
+
+| # | Seção | Componente | Telas mobile (~) | Problema |
+|---|-------|-----------|:-:|----------|
+| 1 | Navbar | `<Navbar>` | 0.1 | OK — hamburger menu funciona |
+| 2 | Hero | `<HeroSection>` | 1.0 | `min-h-dvh` ocupa tela inteira. OK mas define o ritmo. |
+| 3 | Divider | `<SectionDivider>` | 0.2 | Espaço morto decorativo, sem valor informacional |
+| 4 | Features | `<FeaturesSection>` — 6 cards | 3.0 | **Pior ofensor.** 6 cards empilhados com ícone 56px + título + parágrafo + padding cada |
+| 5 | Divider | `<SectionDivider>` | 0.2 | Espaço morto |
+| 6 | How It Works | `<HowItWorksSection>` — 4 steps | 2.0 | 4 cards com ícone RuneCircle + título + descrição. Redundante com Features |
+| 7 | Divider | `<SectionDivider>` | 0.2 | Espaço morto |
+| 8 | Comparison | `<ComparisonSection>` — 5 cards | 3.5 | **Segundo pior.** 5 cards expandidos × 3 sub-rows (Roll20/Beyond/PDM) cada |
+| 9 | Social Proof | `<SocialProofSection>` — 3 cards | 1.5 | 3 testimonials empilhados |
+| 10 | Pricing | `<LpPricingSection>` — 2 cards | 2.5 | Free + Pro (dimmed) + beta banner |
+| 11 | Final CTA | `<FinalCtaSection>` | 1.0 | Redundante — pricing já tem CTA |
+| 12 | Footer | `<Footer>` | 0.5 | OK |
+| | **TOTAL** | | **~15.7** | |
+
+---
+
+## 3. Decisões de Design — Mobile vs Desktop
+
+### Princípio geral
+
+> **Desktop:** experiência imersiva e exploratória — o usuário navega com calma, hovers revelam detalhes, animações criam atmosfera.
+> **Mobile:** experiência de convencimento rápido — hero → valor → prova social → ação. Cada pixel deve justificar o scroll.
+
+Todas as mudanças usam classes condicionais Tailwind (`hidden md:block` / `md:hidden`). **Zero impacto no desktop.**
+
+---
+
+### 3.1 Section Dividers — Ocultar no mobile
+
+| | Desktop | Mobile |
+|---|---------|--------|
+| **Visibilidade** | Visível — ornamento SVG com gradientes gold | **Oculto** (`hidden md:flex`) |
+| **Justificativa** | No desktop criam ritmo visual entre seções widescreen | No mobile adicionam ~60px de espaço morto × 3 = 180px sem valor |
+
+**Economia:** ~0.6 telas
+
+---
+
+### 3.2 Features Section — Grid compacto 2×3
+
+| | Desktop | Mobile (atual) | Mobile (novo) |
+|---|---------|----------------|---------------|
+| **Layout** | Grid 3 colunas, cards com ícone 56px + título + parágrafo | Grid 1 coluna, 6 cards full-width empilhados | **Grid 2 colunas, cards compactos** |
+| **Conteúdo do card** | Emoji box 56px + tag badge + título + descrição | Mesmo que desktop | **Emoji 32px + título apenas.** Sem descrição, sem tag badge |
+| **Ícone decorativo (dados flutuantes)** | Visíveis — d20, d4, d6, d8, d10, sparkles | Visíveis (mesmos) | **Ocultos** (`hidden md:block`) |
+| **Heading da seção** | h2 + subtítulo | h2 + subtítulo | **h2 apenas**, sem subtítulo |
+| **Padding da seção** | `py-24 px-6` | `py-24 px-6` | **`py-12 px-4`** (mobile only) |
+
+**Lógica:** No mobile, os títulos das features são auto-explicativos ("Combat Tracker Completo", "Player View em Tempo Real"). A descrição detalhada é luxo de desktop. O grid 2×3 mostra tudo em ~1 tela vs 3 telas atuais.
+
+**Economia:** ~2.0 telas
+
+---
+
+### 3.3 How It Works — Timeline inline compacta
+
+| | Desktop | Mobile (atual) | Mobile (novo) |
+|---|---------|----------------|---------------|
+| **Layout** | Horizontal flow com FireTrail + QuestPath + RuneCircle por step | Vertical, 4 cards com RuneCircle + título + descrição | **Timeline vertical compacta:** ícone/número inline + título + tempo. Sem descrição. |
+| **Descrição dos passos** | Visível sob cada step | Visível | **Oculta** |
+| **RuneCircle / TorchGlow** | Visível | Visível | **Substituído por número simples com borda gold** |
+| **CTA "Testar Combat Tracker"** | Visível após steps | Visível | **Mantido** |
+| **Padding da seção** | `py-24` | `py-24` | **`py-12`** |
+
+**Formato mobile novo — cada step em 1 linha:**
+```
+① Crie o Encontro .............. ~1 min
+② Role Iniciativa .............. ~30 seg
+③ Compartilhe o Link ........... ~10 seg
+④ Mestre o Combate ............. ao vivo
+```
+
+**Economia:** ~1.5 telas
+
+---
+
+### 3.4 Comparison Section — Resumo de diferenciais
+
+| | Desktop | Mobile (atual) | Mobile (novo) |
+|---|---------|----------------|---------------|
+| **Layout** | Tabela 4 colunas com header, 5 rows, hover effects | 5 cards expandidos, cada um com 3 sub-rows (Roll20/Beyond/PDM) | **3 "killer bullets"** — os 3 diferenciais mais impactantes em formato badge/pill |
+| **Heading** | h2 + subtítulo | h2 + subtítulo | **h2 compacto** |
+| **Conteúdo** | 5 features × 3 competidores | Mesmo (expandido em cards) | **3 bullets de impacto direto** |
+| **Padding** | `py-24` | `py-24` | **`py-12`** |
+
+**Os 3 killer bullets selecionados** (dos 5 rows atuais, priorizados por impacto de conversão):
+
+1. **💰 "Comece grátis"** — vs Roll20 $5-50/mês, D&D Beyond $6/mês ← elimina objeção de preço
+2. **📱 "Player view sem conta"** — link direto, zero fricção ← diferencial único
+3. **📚 "Regras 2014 + 2024 grátis"** — vs módulos pagos dos concorrentes ← valor percebido
+
+Formato visual: cada bullet é um mini-card horizontal com ícone + frase de impacto + badge "vs concorrência" sutil.
+
+**Economia:** ~2.5 telas
+
+---
+
+### 3.5 Social Proof — Testimonial único com indicadores
+
+| | Desktop | Mobile (atual) | Mobile (novo) |
+|---|---------|----------------|---------------|
+| **Layout** | Grid 3 colunas, 3 cards lado a lado | 3 cards empilhados full-width | **1 testimonial visível** + 2 dots indicadores (swipe ou auto-rotate) |
+| **Quote mark SVG** | Visível | Visível | **Mantido** mas menor |
+| **Heading da seção** | h2 + subtítulo | h2 + subtítulo | **Sem heading** — a quote fala por si |
+| **Implementação** | Estático | Estático | **CSS scroll-snap horizontal** (nativo, sem JS library) |
+
+**Nota técnica:** Usar `overflow-x: auto` + `scroll-snap-type: x mandatory` + `scroll-snap-align: center`. Leve, acessível, sem dependência de biblioteca de carrossel.
+
+**Economia:** ~1.0 tela
+
+---
+
+### 3.6 Pricing — Manter, ajustar padding
+
+| | Desktop | Mobile (atual) | Mobile (novo) |
+|---|---------|----------------|---------------|
+| **Layout** | Grid 2 colunas | 2 cards empilhados | **Igual**, mas com padding reduzido |
+| **Beta banner** | Flex row | Flex column | **Igual** |
+| **Card Pro (dimmed)** | Visível | Visível | **Colapsado** — mostrar apenas título + "Em breve" + 1 linha resumo. Sem lista de features. |
+| **Padding** | `py-24 p-8` (cards) | Mesmo | **`py-14 p-5`** (cards mobile) |
+
+**Lógica:** O card Pro está `opacity-60` e sem CTA. No mobile, listar 10 features de algo que não pode ser comprado ainda é desperdício de scroll.
+
+**Economia:** ~0.8 tela
+
+---
+
+### 3.7 Final CTA — Ocultar no mobile
+
+| | Desktop | Mobile (atual) | Mobile (novo) |
+|---|---------|----------------|---------------|
+| **Visibilidade** | Visível — CTA emocional de fechamento | Visível | **Oculto** (`hidden md:block`) |
+| **Justificativa** | No desktop, cria closure emocional após longa jornada | No mobile, o CTA do Pricing já faz esse papel. Seção redundante. |
+
+**Economia:** ~1.0 tela
+
+---
+
+## 4. Resumo Comparativo do Fluxo
+
+### Desktop (inalterado)
+```
+Hero → Divider → Features (6 cards) → Divider → How It Works (4 steps + fire trail)
+→ Divider → Comparison (tabela 4 colunas) → Social Proof (3 cards) → Divider
+→ Pricing (2 cards) → Final CTA → Footer
+```
+
+### Mobile (redesign)
+```
+Hero (1 tela)
+  ↓
+Features — grid 2×3 compacto, só emoji+título (1 tela)
+  ↓
+How It Works — timeline inline, sem descrição (0.7 tela)
+  ↓
+Diferenciais — 3 killer bullets (0.5 tela)
+  ↓
+Social Proof — 1 testimonial com scroll-snap (0.5 tela)
+  ↓
+Pricing — Free card + Pro colapsado (1.5 tela)
+  ↓
+Footer (0.5 tela)
+```
+
+**Total mobile: ~5.7 telas** (vs ~15.7 atuais = **redução de ~64%**)
+
+---
+
+## 5. Regras de Implementação
+
+1. **Breakpoint:** Todas as mudanças se aplicam abaixo de `md:` (< 768px). Acima disso, zero alteração.
+2. **Approach:** Classes condicionais Tailwind — `hidden md:block`, `md:hidden`, padding responsivo (`py-12 md:py-24`).
+3. **Sem novas dependências:** Scroll-snap do Social Proof usa CSS nativo. Nenhuma lib de carrossel.
+4. **Sem novo componente:** Tudo é variação condicional dentro dos componentes existentes.
+5. **Animações mobile:** Manter `animate-fade-in-up` mas remover delays longos (> 0.2s) para sensação de carregamento rápido.
+6. **Touch targets:** Manter `min-h-[44px]` em todos os elementos interativos (WCAG compliance já existente).
+
+---
+
+## 6. Checklist de Implementação
+
+- [ ] `SectionDivider`: adicionar `hidden md:flex` no wrapper
+- [ ] `FeaturesSection`: criar variante mobile grid 2×3 com cards compactos (emoji 32px + título)
+- [ ] `FeaturesSection`: ocultar dados decorativos flutuantes no mobile
+- [ ] `FeaturesSection`: reduzir padding mobile para `py-12 px-4`
+- [ ] `HowItWorksSection`: criar variante mobile timeline compacta (número + título + tempo, sem descrição)
+- [ ] `HowItWorksSection`: reduzir padding mobile
+- [ ] `ComparisonSection`: criar variante mobile "3 killer bullets" substituindo os 5 cards
+- [ ] `ComparisonSection`: reduzir padding mobile
+- [ ] `SocialProofSection`: criar variante mobile scroll-snap horizontal com 1 testimonial visível
+- [ ] `SocialProofSection`: remover heading da seção no mobile
+- [ ] `LpPricingSection`: colapsar card Pro no mobile (título + "Em breve" + resumo)
+- [ ] `LpPricingSection`: reduzir padding mobile
+- [ ] `FinalCtaSection`: ocultar no mobile (`hidden md:block`)
+- [ ] Teste visual em viewports 375px (iPhone SE), 390px (iPhone 14), 412px (Pixel 7)

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,14 @@
   .safe-area-pb {
     padding-bottom: env(safe-area-inset-bottom, 0px);
   }
+  /* Hide scrollbar for horizontal carousels */
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 /* Smooth scroll + offset for fixed navbar */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -246,7 +246,7 @@ function HeroSection() {
 // ── Section Divider ───────────────────────────────────────────────────────────
 function SectionDivider() {
   return (
-    <div className="flex justify-center items-center gap-4 py-4" aria-hidden="true">
+    <div className="hidden md:flex justify-center items-center gap-4 py-4" aria-hidden="true">
       <div className="h-px w-24 bg-gradient-to-r from-transparent via-gold/20 to-gold/20" />
       {/* SVG d6 diamond ornament */}
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="text-gold/30">
@@ -306,44 +306,33 @@ function FeaturesSection() {
   ];
 
   return (
-    <section data-section="features" className="py-24 px-6 relative overflow-hidden" id="features">
-      {/* Decorative layer — floating RPG dice */}
-      <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+    <section data-section="features" className="py-12 md:py-24 px-4 md:px-6 relative overflow-hidden" id="features">
+      {/* Decorative layer — floating RPG dice (desktop only) */}
+      <div className="absolute inset-0 pointer-events-none hidden md:block" aria-hidden="true">
         <div className="absolute top-1/2 left-1/4 -translate-y-1/2 w-[500px] h-[500px] bg-gold/[0.04] rounded-full blur-[120px]" />
-
-        {/* d20 — top-right */}
         <D20Icon className="absolute top-10 right-10 w-24 h-24 text-gold/20 float-drift-3" style={{ animationDelay: "-1s" }} />
         <SparkleIcon className="absolute bottom-16 left-16 w-10 h-10 text-gold/20 float-gentle" />
-
-        {/* d4 — top-left */}
         <D4Icon className="absolute top-8 left-[8%] w-16 h-16 text-gold/15 float-drift-1" />
-
-        {/* d6 — mid-right */}
         <D6Icon className="absolute top-1/3 right-[5%] w-14 h-14 text-gold/12 float-drift-2" />
-
-        {/* d8 — bottom-right */}
         <D8Icon className="absolute bottom-12 right-[12%] w-16 h-16 text-gold/15 float-drift-3" />
-
-        {/* d10 — mid-left */}
         <D10Icon className="absolute top-[55%] left-[3%] w-14 h-14 text-gold/12 float-drift-4" />
-
-        {/* Extra sparkles */}
         <SparkleIcon className="absolute top-[20%] right-[25%] w-7 h-7 text-gold/15 float-drift-1" style={{ animationDelay: "-1.5s" }} />
         <SparkleIcon className="absolute bottom-[30%] left-[20%] w-8 h-8 text-gold/12 float-drift-3" style={{ animationDelay: "-3s" }} />
       </div>
 
       <div className="relative max-w-5xl mx-auto">
-        <div className="text-center mb-16 animate-fade-in">
+        <div className="text-center mb-8 md:mb-16 animate-fade-in">
           <h2 className="text-3xl sm:text-4xl font-display text-foreground mb-4">
             Tudo o que o Mestre precisa
           </h2>
-          <p className="text-muted-foreground max-w-lg mx-auto">
+          <p className="text-muted-foreground max-w-lg mx-auto hidden md:block">
             De iniciativa a pontos de vida, de condições a oráculo de magias.
             Uma ferramenta focada no que importa.
           </p>
         </div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* Desktop: full cards with descriptions */}
+        <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-6">
           {features.map((f, i) => (
             <div
               key={f.title}
@@ -360,6 +349,22 @@ function FeaturesSection() {
               </div>
               <h3 className="font-display text-foreground text-lg mb-2">{f.title}</h3>
               <p className="text-muted-foreground text-sm leading-relaxed">{f.description}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Mobile: compact 2×3 grid — emoji + title only */}
+        <div className="grid grid-cols-2 gap-3 md:hidden">
+          {features.map((f, i) => (
+            <div
+              key={f.title}
+              className="bg-card border border-border rounded-lg p-3 flex items-center gap-2.5 animate-fade-in-up"
+              style={{ animationDelay: `${i * 0.05}s` }}
+            >
+              <div className="w-8 h-8 shrink-0 rounded-lg bg-gradient-to-br from-gold/15 to-gold/5 border border-gold/20 flex items-center justify-center text-base">
+                {f.emoji}
+              </div>
+              <h3 className="font-display text-foreground text-xs leading-tight">{f.title}</h3>
             </div>
           ))}
         </div>
@@ -389,13 +394,14 @@ function SocialProofSection() {
   ];
 
   return (
-    <section data-section="social-proof" className="py-24 px-6 relative overflow-hidden">
+    <section data-section="social-proof" className="py-12 md:py-24 px-4 md:px-6 relative overflow-hidden">
       <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
         <div className="absolute top-1/3 right-1/4 w-[400px] h-[400px] bg-cool/[0.03] rounded-full blur-[120px]" />
       </div>
 
       <div className="relative max-w-5xl mx-auto">
-        <div className="text-center mb-14 animate-fade-in">
+        {/* Desktop heading */}
+        <div className="text-center mb-14 animate-fade-in hidden md:block">
           <h2 className="text-3xl sm:text-4xl font-display text-foreground mb-4">
             O que mestres estão dizendo
           </h2>
@@ -404,14 +410,14 @@ function SocialProofSection() {
           </p>
         </div>
 
-        <div className="grid md:grid-cols-3 gap-6">
+        {/* Desktop: 3-column grid */}
+        <div className="hidden md:grid md:grid-cols-3 gap-6">
           {testimonials.map((t, i) => (
             <div
               key={i}
               className="relative bg-card border border-border rounded-xl p-6 h-full flex flex-col animate-fade-in-up"
               style={{ animationDelay: `${i * 0.1}s` }}
             >
-              {/* Quote mark */}
               <svg width="28" height="21" viewBox="0 0 32 24" fill="none" className="text-gold/20 mb-4 shrink-0" aria-hidden="true">
                 <path d="M0 24V14.4C0 5.33 5.33 1.07 12 0l1.33 3.73C8.53 5.07 7.07 8.53 6.93 12H12v12H0zm18 0V14.4C18 5.33 23.33 1.07 30 0l1.33 3.73C26.53 5.07 25.07 8.53 24.93 12H30v12H18z" fill="currentColor" />
               </svg>
@@ -424,6 +430,35 @@ function SocialProofSection() {
               </div>
             </div>
           ))}
+        </div>
+
+        {/* Mobile: horizontal scroll-snap carousel */}
+        <div className="md:hidden">
+          <div className="flex gap-4 overflow-x-auto snap-x snap-mandatory pb-4 -mx-4 px-4 scrollbar-hide">
+            {testimonials.map((t, i) => (
+              <div
+                key={i}
+                className="relative bg-card border border-border rounded-xl p-5 flex flex-col snap-center shrink-0 w-[85vw] max-w-[320px]"
+              >
+                <svg width="20" height="15" viewBox="0 0 32 24" fill="none" className="text-gold/20 mb-3 shrink-0" aria-hidden="true">
+                  <path d="M0 24V14.4C0 5.33 5.33 1.07 12 0l1.33 3.73C8.53 5.07 7.07 8.53 6.93 12H12v12H0zm18 0V14.4C18 5.33 23.33 1.07 30 0l1.33 3.73C26.53 5.07 25.07 8.53 24.93 12H30v12H18z" fill="currentColor" />
+                </svg>
+                <p className="text-foreground/80 text-sm leading-relaxed flex-1 italic">
+                  &ldquo;{t.quote}&rdquo;
+                </p>
+                <div className="mt-3 pt-3 border-t border-white/[0.06]">
+                  <p className="text-sm font-medium text-foreground">{t.author}</p>
+                  <p className="text-xs text-muted-foreground">{t.role}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          {/* Scroll indicators */}
+          <div className="flex justify-center gap-1.5 mt-2">
+            {testimonials.map((_, i) => (
+              <div key={i} className={`w-1.5 h-1.5 rounded-full ${i === 0 ? "bg-gold/60" : "bg-white/15"}`} />
+            ))}
+          </div>
         </div>
       </div>
     </section>
@@ -466,7 +501,7 @@ function HowItWorksSection() {
   ];
 
   return (
-    <section data-section="how-it-works" id="como-funciona" className="py-24 px-6 bg-surface-secondary/50 relative overflow-hidden">
+    <section data-section="how-it-works" id="como-funciona" className="py-12 md:py-24 px-4 md:px-6 bg-surface-secondary/50 relative overflow-hidden">
       <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
         <div className="absolute top-0 right-0 w-[400px] h-[400px] bg-cool/[0.04] rounded-full blur-[100px]" />
         {/* Subtle grid pattern */}
@@ -480,8 +515,8 @@ function HowItWorksSection() {
       </div>
 
       <div className="relative max-w-5xl mx-auto">
-        <div className="text-center mb-16 animate-fade-in">
-          <h2 className="text-3xl sm:text-4xl font-display text-foreground mb-4">
+        <div className="text-center mb-8 md:mb-16 animate-fade-in">
+          <h2 className="text-3xl sm:text-4xl font-display text-foreground mb-2 md:mb-4">
             Como funciona
           </h2>
           <p className="text-muted-foreground">4 passos. 3 minutos. Zero setup.</p>
@@ -542,44 +577,36 @@ function HowItWorksSection() {
           </div>
         </div>
 
-        {/* Mobile: vertical cards */}
-        <div className="md:hidden grid grid-cols-1 gap-6">
-          {steps.map((s, i) => {
-            const isLast = s.step === TOTAL_STEPS;
+        {/* Mobile: compact inline timeline */}
+        <div className="md:hidden flex flex-col gap-0 animate-fade-in-up">
+          {steps.map((s) => {
             const stepColor = getFireStepColor(s.step, TOTAL_STEPS);
-            const circle = (
-              <RuneCircle step={s.step} total={TOTAL_STEPS} size="md" active={isLast} />
-            );
+            const isLast = s.step === TOTAL_STEPS;
 
             return (
               <div
                 key={s.step}
-                className="flex gap-5 group animate-fade-in-up"
-                style={{ animationDelay: `${i * 0.1}s` }}
+                className="flex items-center gap-3 py-3 border-b border-white/[0.06] last:border-b-0"
               >
-                <div className="relative shrink-0">
-                  {isLast ? (
-                    <TorchGlow intensity="medium" className="rounded-full">
-                      {circle}
-                    </TorchGlow>
-                  ) : (
-                    circle
-                  )}
-                  <span className="absolute -bottom-1 -right-1 text-base leading-none">{s.emoji}</span>
+                <div
+                  className="w-8 h-8 shrink-0 rounded-full flex items-center justify-center text-sm font-bold font-mono"
+                  style={{
+                    color: stepColor,
+                    border: `1.5px solid ${stepColor}`,
+                    background: isLast ? `${stepColor}15` : "transparent",
+                    boxShadow: isLast ? `0 0 12px ${stepColor}30` : "none",
+                  }}
+                >
+                  {s.step}
                 </div>
-                <div className="pt-2">
-                  <div className="flex items-center gap-2 mb-1">
-                    <h3 className="font-display text-foreground text-lg group-hover:text-gold transition-colors duration-200">
-                      {s.title}
-                    </h3>
-                    <span
-                      className="text-[10px] font-mono uppercase tracking-wider"
-                      style={{ color: stepColor, opacity: 0.7 }}
-                    >
-                      {s.time}
-                    </span>
-                  </div>
-                  <p className="text-muted-foreground text-sm leading-relaxed">{s.description}</p>
+                <div className="flex-1 flex items-center justify-between gap-2 min-w-0">
+                  <h3 className="font-display text-foreground text-sm truncate">{s.title}</h3>
+                  <span
+                    className="text-[10px] font-mono uppercase tracking-wider shrink-0"
+                    style={{ color: stepColor, opacity: 0.7 }}
+                  >
+                    {s.time}
+                  </span>
                 </div>
               </div>
             );
@@ -693,7 +720,7 @@ function ComparisonSection() {
 
   return (
     // Darker "stage" bg — breaks visual monotony from the rest of the page
-    <section data-section="comparison" id="comparativo" className="py-24 px-6 relative overflow-hidden bg-[#0c0c16]">
+    <section data-section="comparison" id="comparativo" className="py-12 md:py-24 px-4 md:px-6 relative overflow-hidden bg-[#0c0c16]">
       <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[700px] h-[400px] bg-gold/[0.025] rounded-full blur-[140px]" />
       </div>
@@ -792,42 +819,37 @@ function ComparisonSection() {
           })}
         </div>
 
-        {/* ── Mobile cards (hidden on desktop) ── */}
+        {/* ── Mobile: 3 killer differentiators ── */}
         <div className="md:hidden flex flex-col gap-3 animate-fade-in-up" style={{ animationDelay: "0.1s" }}>
-          {rows.map((row) => (
+          {[
+            {
+              icon: "💰",
+              title: "Comece grátis",
+              description: "Roll20 cobra $5–50/mês. D&D Beyond $6/mês. Pocket DM é grátis.",
+            },
+            {
+              icon: "📱",
+              title: "Player view sem conta",
+              description: "Gere um link. Jogadores abrem no celular. Sem app, sem cadastro.",
+            },
+            {
+              icon: "📚",
+              title: "Regras 2014 + 2024 grátis",
+              description: "3000+ monstros e 900+ magias. Nos concorrentes, é módulo pago.",
+            },
+          ].map((item) => (
             <div
-              key={row.feature}
-              className={`rounded-xl overflow-hidden ${row.knockout ? "ring-1 ring-gold/30" : ""}`}
+              key={item.title}
+              className="flex items-start gap-3 rounded-xl px-4 py-3.5"
               style={{
                 background: "#13131f",
                 border: "1px solid rgba(255,255,255,0.07)",
               }}
             >
-              {/* Feature header */}
-              <div className={`px-5 py-4 flex items-center gap-3 ${row.knockout ? "bg-gold/[0.06]" : "bg-white/[0.02]"}`}>
-                <span className="text-xl leading-none shrink-0">{row.icon}</span>
-                <span className="text-[15px] font-semibold text-white/90">{row.feature}</span>
-              </div>
-              {/* Competitor rows */}
-              <div className="divide-y divide-white/[0.04]">
-                <div className="px-5 py-3 flex items-center justify-between">
-                  <span className="text-[11px] font-semibold text-white/30 uppercase tracking-wider">Roll20</span>
-                  <CompCell val={row.roll20} />
-                </div>
-                <div className="px-5 py-3 flex items-center justify-between">
-                  <span className="text-[11px] font-semibold text-white/30 uppercase tracking-wider">D&amp;D Beyond</span>
-                  <CompCell val={row.beyond} />
-                </div>
-                <div
-                  className="px-5 py-3 flex items-center justify-between"
-                  style={{
-                    background: row.knockout ? "rgba(212,168,83,0.12)" : "rgba(212,168,83,0.07)",
-                    borderTop: "1px solid rgba(212,168,83,0.15)",
-                  }}
-                >
-                  <span className="text-[11px] font-bold text-gold/80 uppercase tracking-wider">Pocket DM</span>
-                  <CompCell val={row.pocketdm} highlight />
-                </div>
+              <span className="text-xl leading-none shrink-0 mt-0.5">{item.icon}</span>
+              <div className="min-w-0">
+                <h3 className="text-sm font-semibold text-foreground mb-0.5">{item.title}</h3>
+                <p className="text-xs text-muted-foreground leading-relaxed">{item.description}</p>
               </div>
             </div>
           ))}
@@ -847,7 +869,7 @@ function ComparisonSection() {
 // ── Final CTA ─────────────────────────────────────────────────────────────────
 function FinalCtaSection() {
   return (
-    <section data-section="final-cta" className="py-24 px-6 relative overflow-hidden">
+    <section data-section="final-cta" className="hidden md:block py-24 px-6 relative overflow-hidden">
       {/* Ambient glow */}
       <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[300px] bg-gold/[0.06] rounded-full blur-[100px]" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -322,7 +322,7 @@ function FeaturesSection() {
 
       <div className="relative max-w-5xl mx-auto">
         <div className="text-center mb-8 md:mb-16 animate-fade-in">
-          <h2 className="text-3xl sm:text-4xl font-display text-foreground mb-4">
+          <h2 className="text-3xl sm:text-4xl font-display text-foreground mb-2 md:mb-4">
             Tudo o que o Mestre precisa
           </h2>
           <p className="text-muted-foreground max-w-lg mx-auto hidden md:block">
@@ -400,12 +400,11 @@ function SocialProofSection() {
       </div>
 
       <div className="relative max-w-5xl mx-auto">
-        {/* Desktop heading */}
-        <div className="text-center mb-14 animate-fade-in hidden md:block">
-          <h2 className="text-3xl sm:text-4xl font-display text-foreground mb-4">
+        <div className="text-center mb-6 md:mb-14 animate-fade-in">
+          <h2 className="text-2xl md:text-3xl sm:text-4xl font-display text-foreground mb-2 md:mb-4">
             O que mestres estão dizendo
           </h2>
-          <p className="text-muted-foreground text-sm">
+          <p className="text-muted-foreground text-sm hidden md:block">
             Feedback real de quem usa na mesa toda semana.
           </p>
         </div>
@@ -453,12 +452,7 @@ function SocialProofSection() {
               </div>
             ))}
           </div>
-          {/* Scroll indicators */}
-          <div className="flex justify-center gap-1.5 mt-2">
-            {testimonials.map((_, i) => (
-              <div key={i} className={`w-1.5 h-1.5 rounded-full ${i === 0 ? "bg-gold/60" : "bg-white/15"}`} />
-            ))}
-          </div>
+          <p className="text-center text-[10px] text-muted-foreground/50 mt-2">Deslize para ver mais</p>
         </div>
       </div>
     </section>
@@ -869,31 +863,29 @@ function ComparisonSection() {
 // ── Final CTA ─────────────────────────────────────────────────────────────────
 function FinalCtaSection() {
   return (
-    <section data-section="final-cta" className="hidden md:block py-24 px-6 relative overflow-hidden">
+    <section data-section="final-cta" className="py-10 md:py-24 px-4 md:px-6 relative overflow-hidden">
       {/* Ambient glow */}
       <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[600px] h-[300px] bg-gold/[0.06] rounded-full blur-[100px]" />
       </div>
 
-
-
-      <div className="relative max-w-2xl mx-auto text-center space-y-6 animate-fade-in-up">
-        <h2 className="text-3xl sm:text-4xl font-display text-foreground">
+      <div className="relative max-w-2xl mx-auto text-center space-y-4 md:space-y-6 animate-fade-in-up">
+        <h2 className="text-2xl md:text-3xl sm:text-4xl font-display text-foreground">
           Pronto para mestrar{" "}
           <span className="text-gold drop-shadow-[0_0_16px_rgba(212,168,83,0.4)]">melhor</span>?
         </h2>
-        <p className="text-muted-foreground text-lg">
+        <p className="text-muted-foreground text-sm md:text-lg hidden md:block">
           Crie sua conta em segundos e transforme sua próxima sessão.
         </p>
 
         <div className="flex flex-col items-center gap-3 pt-2">
           <Link
             href="/auth/sign-up"
-            className="group relative overflow-hidden inline-flex items-center gap-2.5 px-10 py-4 bg-gold text-surface-primary font-semibold text-lg rounded-lg hover:shadow-gold-glow-lg hover:-translate-y-[2px] active:translate-y-0 transition-all duration-[200ms] min-h-[52px] btn-shimmer"
+            className="group relative overflow-hidden inline-flex items-center gap-2.5 px-8 md:px-10 py-3 md:py-4 bg-gold text-surface-primary font-semibold text-base md:text-lg rounded-lg hover:shadow-gold-glow-lg hover:-translate-y-[2px] active:translate-y-0 transition-all duration-[200ms] min-h-[48px] md:min-h-[52px] btn-shimmer"
           >
-            <SparkleIcon className="w-5 h-5 opacity-70 group-hover:opacity-100 group-hover:scale-125 transition-all duration-200" />
+            <SparkleIcon className="w-4 h-4 md:w-5 md:h-5 opacity-70 group-hover:opacity-100 group-hover:scale-125 transition-all duration-200" />
             Começar Agora — é Grátis
-            <ArrowRight className="w-5 h-5 opacity-70 group-hover:opacity-100 group-hover:translate-x-1 transition-all duration-200" />
+            <ArrowRight className="w-4 h-4 md:w-5 md:h-5 opacity-70 group-hover:opacity-100 group-hover:translate-x-1 transition-all duration-200" />
           </Link>
           <Link
             href="/try"

--- a/components/marketing/LpPricingSection.tsx
+++ b/components/marketing/LpPricingSection.tsx
@@ -151,47 +151,30 @@ export function LpPricingSection() {
               </span>
             </div>
 
-            {/* Mobile: compact summary */}
-            <div className="md:hidden">
-              <div className="flex items-baseline gap-1 mb-2">
-                <span className="text-2xl font-mono font-bold text-foreground tracking-tight">
-                  {t("pro_price")}
-                </span>
-                <span className="text-sm text-muted-foreground">
-                  {t("pro_period")}
-                </span>
-              </div>
-              <p className="text-sm text-muted-foreground">
-                {t("pro_includes_free")}
-              </p>
+            <div className="flex items-baseline gap-1 mb-2 md:mb-4">
+              <span className="text-2xl md:text-4xl font-mono font-bold text-foreground tracking-tight">
+                {t("pro_price")}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {t("pro_period")}
+              </span>
             </div>
+
+            <p className="text-sm text-muted-foreground mb-2 md:mb-4">
+              {t("pro_includes_free")}
+            </p>
 
             {/* Desktop: full feature list */}
-            <div className="hidden md:block">
-              <div className="flex items-baseline gap-1 mb-4">
-                <span className="text-4xl font-mono font-bold text-foreground tracking-tight">
-                  {t("pro_price")}
-                </span>
-                <span className="text-sm text-muted-foreground">
-                  {t("pro_period")}
-                </span>
-              </div>
-
-              <p className="text-sm text-muted-foreground mb-4">
-                {t("pro_includes_free")}
-              </p>
-
-              <ul className="space-y-2.5 flex-1">
-                {proFeatureKeys.map((key) => (
-                  <li key={key} className="flex items-start gap-2.5">
-                    <CheckIcon className="w-4 h-4 text-white/30 shrink-0 mt-0.5" />
-                    <span className="text-sm text-foreground/60">
-                      {t(key)}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
+            <ul className="space-y-2.5 flex-1 hidden md:block">
+              {proFeatureKeys.map((key) => (
+                <li key={key} className="flex items-start gap-2.5">
+                  <CheckIcon className="w-4 h-4 text-white/30 shrink-0 mt-0.5" />
+                  <span className="text-sm text-foreground/60">
+                    {t(key)}
+                  </span>
+                </li>
+              ))}
+            </ul>
           </div>
         </div>
       </div>

--- a/components/marketing/LpPricingSection.tsx
+++ b/components/marketing/LpPricingSection.tsx
@@ -37,7 +37,7 @@ export function LpPricingSection() {
     <section
       data-section="lp-pricing"
       id="precos"
-      className="py-24 px-6 relative overflow-hidden bg-[#0d0d14]"
+      className="py-14 md:py-24 px-4 md:px-6 relative overflow-hidden bg-[#0d0d14]"
     >
       {/* Ambient glow */}
       <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
@@ -78,7 +78,7 @@ export function LpPricingSection() {
         >
           {/* ── Free Card ── */}
           <div
-            className="relative rounded-2xl bg-card p-8 flex flex-col transition-all duration-200 hover:ring-2 hover:ring-gold/40"
+            className="relative rounded-2xl bg-card p-5 md:p-8 flex flex-col transition-all duration-200 hover:ring-2 hover:ring-gold/40"
             style={{
               background: "#13131f",
               border: "1px solid rgba(212,168,83,0.25)",
@@ -129,9 +129,9 @@ export function LpPricingSection() {
             </Link>
           </div>
 
-          {/* ── Pro Card (dimmed) ── */}
+          {/* ── Pro Card (dimmed) — collapsed on mobile ── */}
           <div
-            className="relative rounded-2xl border border-border p-8 flex flex-col opacity-60 cursor-default"
+            className="relative rounded-2xl border border-border p-5 md:p-8 flex flex-col opacity-60 cursor-default"
             aria-disabled="true"
             style={{
               background: "#13131f",
@@ -139,7 +139,6 @@ export function LpPricingSection() {
               boxShadow: "0 24px 64px rgba(0,0,0,0.3)",
             }}
           >
-            {/* Coming soon badge */}
             <div className="flex items-center gap-3 mb-3">
               <h3 className="text-xl font-display text-foreground">
                 {t("pro_title")}
@@ -152,31 +151,47 @@ export function LpPricingSection() {
               </span>
             </div>
 
-            <div className="flex items-baseline gap-1 mb-4">
-              <span className="text-4xl font-mono font-bold text-foreground tracking-tight">
-                {t("pro_price")}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                {t("pro_period")}
-              </span>
+            {/* Mobile: compact summary */}
+            <div className="md:hidden">
+              <div className="flex items-baseline gap-1 mb-2">
+                <span className="text-2xl font-mono font-bold text-foreground tracking-tight">
+                  {t("pro_price")}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {t("pro_period")}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {t("pro_includes_free")}
+              </p>
             </div>
 
-            <p className="text-sm text-muted-foreground mb-4">
-              {t("pro_includes_free")}
-            </p>
+            {/* Desktop: full feature list */}
+            <div className="hidden md:block">
+              <div className="flex items-baseline gap-1 mb-4">
+                <span className="text-4xl font-mono font-bold text-foreground tracking-tight">
+                  {t("pro_price")}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {t("pro_period")}
+                </span>
+              </div>
 
-            <ul className="space-y-2.5 flex-1">
-              {proFeatureKeys.map((key) => (
-                <li key={key} className="flex items-start gap-2.5">
-                  <CheckIcon className="w-4 h-4 text-white/30 shrink-0 mt-0.5" />
-                  <span className="text-sm text-foreground/60">
-                    {t(key)}
-                  </span>
-                </li>
-              ))}
-            </ul>
+              <p className="text-sm text-muted-foreground mb-4">
+                {t("pro_includes_free")}
+              </p>
 
-            {/* No CTA button for Pro */}
+              <ul className="space-y-2.5 flex-1">
+                {proFeatureKeys.map((key) => (
+                  <li key={key} className="flex items-start gap-2.5">
+                    <CheckIcon className="w-4 h-4 text-white/30 shrink-0 mt-0.5" />
+                    <span className="text-sm text-foreground/60">
+                      {t(key)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Redesign mobile-only da Landing Page** — reduz de ~15 telas de scroll para ~6 (64% de redução)
- Zero impacto no desktop — todas as mudanças via breakpoints Tailwind (`md:hidden` / `hidden md:block`)
- Inclui UX spec documentando todas as decisões de design

## Mudanças por seção (mobile only)

| Seção | Antes | Depois |
|-------|-------|--------|
| Section Dividers | 3 ornamentos decorativos | Ocultos |
| Features | 6 cards full com descrição | Grid 2×3 compacto (emoji + título) |
| How It Works | 4 cards com RuneCircle + descrição | Timeline inline (nº + título + tempo) |
| Comparison | 5 cards × 3 sub-rows cada | 3 killer bullets de diferencial |
| Social Proof | 3 cards empilhados | Carrossel horizontal scroll-snap |
| Pricing Pro | Card com 10 features listadas | Colapsado (título + preço + "Em breve") |
| Final CTA | Seção full-size | Versão compacta responsiva |

## Arquivos alterados

- `app/page.tsx` — variantes mobile para cada seção
- `components/marketing/LpPricingSection.tsx` — Pro card responsivo
- `app/globals.css` — utilitário `.scrollbar-hide` para carrossel
- `_bmad-output/planning-artifacts/ux-mobile-lp-redesign.md` — UX spec

## Test plan

- [ ] Verificar desktop (1280px+) permanece inalterado
- [ ] Testar mobile 375px (iPhone SE) — grid 2×3, timeline, bullets, carrossel
- [ ] Testar mobile 390px (iPhone 14) — mesmos checks
- [ ] Testar mobile 412px (Pixel 7) — mesmos checks
- [ ] Verificar acessibilidade: todos os h2 visíveis, touch targets >= 44px
- [ ] Verificar scroll-snap no carrossel de testimonials
- [ ] Confirmar "Deslize para ver mais" aparece sob carrossel

https://claude.ai/code/session_019k21S4uHgr8f2w89iXP3HX