### PR TITLE
feat: audio layering, soundboard redesign, UX fixes

### DIFF
--- a/_bmad-output/implementation-artifacts/tech-spec-audio-layering-ui.md
+++ b/_bmad-output/implementation-artifacts/tech-spec-audio-layering-ui.md
@@ -1,0 +1,190 @@
+# Tech Spec: Audio Layering Livre — Atualização de UI e Broadcast
+
+## Resumo
+
+Atualizar os 3 componentes de UI do DM + o listener do player + tipos realtime para suportar **layering livre de áudio**: múltiplos loops ambient/music simultâneos com controle individual (play/stop por loop) e "Parar Tudo".
+
+O store (`audio-store.ts`) já foi reescrito com suporte a `activeLoops: ActiveLoop[]`. Esta spec cobre a camada de UI e broadcast.
+
+---
+
+## Estado Atual
+
+### Pronto (store)
+
+| Feature | Método | Localização |
+|---------|--------|-------------|
+| Múltiplos loops simultâneos | `activeLoops: ActiveLoop[]` | `audio-store.ts:41` |
+| Toggle individual | `playAmbient(presetId)` — adiciona ou remove do array | `audio-store.ts:142` |
+| Stop individual | `stopLoop(presetId)` | `audio-store.ts:183` |
+| Query individual | `isLoopActive(presetId): boolean` | `audio-store.ts:226` |
+| Stop todos os loops | `stopAmbient()` | `audio-store.ts:198` |
+| Stop tudo (loops + one-shot) | `stopAllAudio()` | `audio-store.ts:207` |
+| Backward compat | `activeAmbientId` aponta para `activeLoops[0]?.id` | `audio-store.ts:44` |
+
+### Pendente (esta spec)
+
+| Componente | Problema |
+|------------|----------|
+| `SoundboardPageClient.tsx` | Usa `activeAmbientId === preset.id` (single-loop) |
+| `DmAtmospherePanel.tsx` | Usa `activeAmbientId === preset.id` (single-loop) |
+| `DmSoundboard.tsx` | Usa `activeAmbientId === preset.id` + chama `stopAmbient()` no broadcast |
+| `PlayerJoinClient.tsx` | `audio:ambient_stop` chama `stopAmbient()` (para TODOS os loops) |
+| `lib/types/realtime.ts` | Não tem evento `audio:loop_stop` com `sound_id` |
+| `messages/*.json` | Falta chave `now_playing_count` |
+
+---
+
+## Mudanças por Arquivo
+
+### 1. `lib/types/realtime.ts` — Novo evento broadcast
+
+**Adicionar** tipo `RealtimeLoopStop`:
+
+```ts
+export interface RealtimeLoopStop {
+  type: "audio:loop_stop";
+  sound_id: string;
+}
+```
+
+**Adicionar** `"audio:loop_stop"` ao union `RealtimeBroadcastEvent`.
+
+> `audio:ambient_stop` (sem payload) continua existindo para "Parar Tudo".
+> `audio:loop_stop` (com `sound_id`) é o novo evento para stop individual.
+
+### 2. `components/dashboard/SoundboardPageClient.tsx` — Soundboard page
+
+**Substituições:**
+- `useAudioStore((s) => s.activeAmbientId)` → `useAudioStore((s) => s.isLoopActive)` + `useAudioStore((s) => s.activeLoops)`
+- Remover import de `playAmbient` separado (já vem do store)
+- `activeAmbientId === preset.id` → `isLoopActive(preset.id)` (~1 ocorrência na linha 138)
+
+**Adicionar "Now Playing" bar** entre a seção de presets e o grid:
+- Visível quando `activeLoops.length > 0`
+- Lista de chips: cada um mostra `icon + nome + botão [×]` que chama `stopLoop(id)`
+- Botão "Parar Tudo" que chama `stopAllAudio()`
+
+**Adicionar** import de `stopLoop` e `stopAllAudio` do store.
+
+### 3. `components/audio/DmAtmospherePanel.tsx` — Painel flutuante in-combat
+
+**Substituições (15 ocorrências):**
+- Linha 75: `useAudioStore((s) => s.activeAmbientId)` → `useAudioStore((s) => s.isLoopActive)` + `useAudioStore((s) => s.activeLoops)`
+- Adicionar: `const stopLoop = useAudioStore((s) => s.stopLoop);`
+- Linha 128: `activeAmbientId === presetId` → `isLoopActive(presetId)` no `handleAmbientToggle`
+- Linha 138: dependency array `[activeAmbientId, ...]` → `[isLoopActive, ...]`
+- Linha 173: `!!activeAmbientId` → `activeLoops.length > 0`
+- Linhas 287, 308, 338: `activeAmbientId === preset.id` → `isLoopActive(preset.id)`
+
+**Broadcast no `handleAmbientToggle`:**
+```ts
+const wasPlaying = isLoopActive(presetId);
+playAmbient(presetId);
+if (onBroadcast) {
+  if (wasPlaying) {
+    onBroadcast("audio:loop_stop", { sound_id: presetId });  // stop individual
+  } else {
+    onBroadcast("audio:ambient_start", { sound_id: presetId });
+  }
+}
+```
+
+**Broadcast no `handleStopAll`:**
+```ts
+stopAllAudio();
+onBroadcast?.("audio:ambient_stop", {});  // mantém evento sem payload = stop tudo
+```
+
+**Now Playing (sounds tab):**
+Substituir o indicador simples de 1 linha por lista de chips com stop individual:
+```
+🎵 Tocando (3)                    [Parar Tudo]
+🌧️ Chuva [×]  ⚔️ Batalha [×]  🏰 Taverna [×]
+```
+
+### 4. `components/audio/DmSoundboard.tsx` — Soundboard legacy (combat)
+
+Mesmas substituições do DmAtmospherePanel:
+- `activeAmbientId` → `isLoopActive` + `activeLoops` (~12 ocorrências)
+- `stopAmbient()` → `stopLoop(id)` para stop individual ou `stopAllAudio()` para parar tudo
+- `handleAmbientToggle` broadcast: usar `audio:loop_stop` com `sound_id`
+- Adicionar now playing multi-chip no header do panel e no `ambientOnly` mode
+- `hasActiveAudio` check: `!!activeAmbientId` → `activeLoops.length > 0`
+
+### 5. `components/player/PlayerJoinClient.tsx` — Player listener
+
+**Adicionar** listener para o novo evento:
+
+```ts
+.on("broadcast", { event: "audio:loop_stop" }, ({ payload }) => {
+  if (payload.sound_id) {
+    useAudioStore.getState().stopLoop(payload.sound_id);
+  }
+})
+```
+
+> `audio:ambient_stop` continua chamando `stopAmbient()` (para tudo).
+> `audio:loop_stop` chama `stopLoop(sound_id)` (para individual).
+> `audio:ambient_start` continua chamando `playAmbient(sound_id)` (adiciona ao array — funciona sem mudança!).
+
+### 6. `messages/pt-BR.json` + `messages/en.json` — i18n
+
+| Chave (namespace `audio`) | pt-BR | en |
+|---------------------------|-------|----|
+| `now_playing_count` | `Tocando ({count})` | `Playing ({count})` |
+
+Chaves existentes reutilizadas:
+- `dm_stop_all` = "Parar Tudo" / "Stop All"
+- `dm_stop_ambient` = "Parar" / "Stop"
+
+---
+
+## UX do "Now Playing" (componente compartilhado)
+
+Layout dos chips ativos (usado nos 3 componentes):
+
+```
+┌──────────────────────────────────────────────────┐
+│ 🎵 Tocando (2)                      [Parar Tudo] │
+│ ┌──────────────┐ ┌──────────────┐                │
+│ │ 🌧️ Chuva  × │ │ ⚔️ Batalha × │                │
+│ └──────────────┘ └──────────────┘                │
+└──────────────────────────────────────────────────┘
+```
+
+- Chips são `flex-wrap` para acomodar múltiplos
+- Cada chip: `bg-emerald-500/15 border border-emerald-500/30 text-emerald-400 rounded-full px-2.5 py-1 text-xs`
+- Botão `×` no chip: `hover:text-red-400`, chama `stopLoop(id)` + broadcast `audio:loop_stop`
+- "Parar Tudo": `text-muted-foreground hover:text-red-400`, chama `stopAllAudio()` + broadcast `audio:ambient_stop`
+
+---
+
+## Impacto no Broadcast (Player-Side)
+
+| Ação do DM | Evento Broadcast | Ação no Player |
+|------------|-----------------|----------------|
+| Clica preset inativo | `audio:ambient_start { sound_id }` | `playAmbient(id)` — adiciona loop |
+| Clica preset ativo (toggle off) | `audio:loop_stop { sound_id }` | `stopLoop(id)` — remove 1 loop |
+| "Parar Tudo" | `audio:ambient_stop {}` | `stopAmbient()` — remove todos |
+
+---
+
+## Fora de Escopo
+
+- Custom sounds no layering (são one-shot, não loops)
+- Volume individual por loop (usa volume global)
+- Limite máximo de loops simultâneos (sem limite artificial)
+- Atualização de testes e2e (posterior)
+- Persistência de loops ativos entre reloads
+
+---
+
+## Ordem de Implementação
+
+1. `lib/types/realtime.ts` — tipo novo (sem dependências)
+2. `messages/*.json` — chave i18n nova
+3. `components/player/PlayerJoinClient.tsx` — listener novo (backward compat)
+4. `components/dashboard/SoundboardPageClient.tsx` — mais simples (sem broadcast)
+5. `components/audio/DmAtmospherePanel.tsx` — com broadcast
+6. `components/audio/DmSoundboard.tsx` — com broadcast + ambientOnly mode

--- a/components/audio/DmAtmospherePanel.tsx
+++ b/components/audio/DmAtmospherePanel.tsx
@@ -72,8 +72,10 @@ export function DmAtmospherePanel({
   const y = useMotionValue(0);
   const dragControls = useDragControls();
 
-  const activeAmbientId = useAudioStore((s) => s.activeAmbientId);
+  const isLoopActive = useAudioStore((s) => s.isLoopActive);
+  const activeLoops = useAudioStore((s) => s.activeLoops);
   const playAmbient = useAudioStore((s) => s.playAmbient);
+  const stopLoop = useAudioStore((s) => s.stopLoop);
   const playSound = useAudioStore((s) => s.playSound);
   const stopAllAudio = useAudioStore((s) => s.stopAllAudio);
   const volume = useAudioStore((s) => s.volume);
@@ -125,17 +127,17 @@ export function DmAtmospherePanel({
 
   const handleAmbientToggle = useCallback(
     (presetId: string) => {
-      const wasPlaying = activeAmbientId === presetId;
+      const wasPlaying = isLoopActive(presetId);
       playAmbient(presetId);
       if (onBroadcast) {
         if (wasPlaying) {
-          onBroadcast("audio:ambient_stop", {});
+          onBroadcast("audio:loop_stop", { sound_id: presetId });
         } else {
           onBroadcast("audio:ambient_start", { sound_id: presetId });
         }
       }
     },
-    [activeAmbientId, playAmbient, onBroadcast]
+    [isLoopActive, playAmbient, onBroadcast]
   );
 
   const handleSfxPlay = useCallback(
@@ -170,7 +172,7 @@ export function DmAtmospherePanel({
     persistState({ collapsed: next });
   }, [collapsed, persistState]);
 
-  const hasActiveAudio = !!activeAmbientId;
+  const hasActiveAudio = activeLoops.length > 0;
   const hasActiveWeather = weatherEffect !== "none";
   const hasActiveAnything = hasActiveAudio || hasActiveWeather;
 
@@ -280,22 +282,40 @@ export function DmAtmospherePanel({
             {activeTab === "sounds" && (
               <div>
                 {hasActiveAudio && (
-                  <div className="flex items-center justify-between mb-3">
-                    <span className="text-xs text-emerald-400">
-                      {t("dm_ambient_playing", {
-                        name: t(
-                          `preset_${activeAmbientId!.replace("ambient-", "ambient_").replace("music-", "music_")}` as Parameters<typeof t>[0]
-                        ),
-                      })}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={handleStopAll}
-                      className="text-xs text-muted-foreground hover:text-red-400 transition-colors flex items-center gap-1 min-h-[28px] px-2"
-                    >
-                      <Square className="w-3 h-3" />
-                      {t("dm_stop_all")}
-                    </button>
+                  <div className="mb-3">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-xs font-medium text-emerald-400">
+                        🎵 {t("now_playing_count", { count: activeLoops.length })}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={handleStopAll}
+                        className="text-xs text-muted-foreground hover:text-red-400 transition-colors flex items-center gap-1 min-h-[28px] px-2"
+                      >
+                        <Square className="w-3 h-3" />
+                        {t("dm_stop_all")}
+                      </button>
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {activeLoops.map((loop) => (
+                        <span
+                          key={loop.id}
+                          className="inline-flex items-center gap-1 bg-emerald-500/15 border border-emerald-500/30 text-emerald-400 rounded-full px-2 py-0.5 text-[10px]"
+                        >
+                          {loop.icon} {t(`preset_${loop.label?.replace("ambient-", "ambient_").replace("music-", "music_")}` as Parameters<typeof t>[0])}
+                          <button
+                            type="button"
+                            onClick={() => {
+                              stopLoop(loop.id);
+                              onBroadcast?.("audio:loop_stop", { sound_id: loop.id });
+                            }}
+                            className="hover:text-red-400 transition-colors"
+                          >
+                            <X className="w-2.5 h-2.5" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
                   </div>
                 )}
 
@@ -305,7 +325,7 @@ export function DmAtmospherePanel({
                 </h4>
                 <div className="grid grid-cols-3 gap-2 mb-3">
                   {ambientPresets.map((preset) => {
-                    const isActive = activeAmbientId === preset.id;
+                    const isActive = isLoopActive(preset.id);
                     return (
                       <button
                         key={preset.id}
@@ -335,7 +355,7 @@ export function DmAtmospherePanel({
                 </h4>
                 <div className="grid grid-cols-3 gap-2 mb-3">
                   {musicPresets.map((preset) => {
-                    const isActive = activeAmbientId === preset.id;
+                    const isActive = isLoopActive(preset.id);
                     return (
                       <button
                         key={preset.id}

--- a/components/audio/DmSoundboard.tsx
+++ b/components/audio/DmSoundboard.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslations } from "next-intl";
-import { Volume2, Square } from "lucide-react";
+import { Volume2, Square, X } from "lucide-react";
 import { useAudioStore } from "@/lib/stores/audio-store";
 import { getAmbientPresets, getMusicPresets, getSfxPresets } from "@/lib/utils/audio-presets";
 
@@ -24,9 +24,10 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
   const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
-  const activeAmbientId = useAudioStore((s) => s.activeAmbientId);
+  const isLoopActive = useAudioStore((s) => s.isLoopActive);
+  const activeLoops = useAudioStore((s) => s.activeLoops);
   const playAmbient = useAudioStore((s) => s.playAmbient);
-  const stopAmbient = useAudioStore((s) => s.stopAmbient);
+  const stopLoop = useAudioStore((s) => s.stopLoop);
   const playSound = useAudioStore((s) => s.playSound);
   const stopAllAudio = useAudioStore((s) => s.stopAllAudio);
 
@@ -55,18 +56,18 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
 
   const handleAmbientToggle = useCallback(
     (presetId: string) => {
-      const wasPlaying = activeAmbientId === presetId;
+      const wasPlaying = isLoopActive(presetId);
       playAmbient(presetId);
 
       if (onBroadcast) {
         if (wasPlaying) {
-          onBroadcast("audio:ambient_stop", {});
+          onBroadcast("audio:loop_stop", { sound_id: presetId });
         } else {
           onBroadcast("audio:ambient_start", { sound_id: presetId });
         }
       }
     },
-    [activeAmbientId, playAmbient, onBroadcast]
+    [isLoopActive, playAmbient, onBroadcast]
   );
 
   const handleSfxPlay = useCallback(
@@ -108,7 +109,7 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
 
         <div className="flex flex-wrap gap-2">
           {ambientPresets.map((preset) => {
-            const isActive = activeAmbientId === preset.id;
+            const isActive = isLoopActive(preset.id);
             return (
               <button
                 key={preset.id}
@@ -133,23 +134,41 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
           })}
         </div>
 
-        {activeAmbientId && (
-          <div className="mt-2 flex items-center justify-between">
-            <span className="text-xs text-emerald-400">
-              {t("dm_ambient_playing", {
-                name: t(
-                  `preset_${activeAmbientId.replace("ambient-", "ambient_")}` as Parameters<typeof t>[0]
-                ),
-              })}
-            </span>
-            <button
-              type="button"
-              onClick={() => { stopAmbient(); onBroadcast?.("audio:ambient_stop", {}); }}
-              className="text-xs text-muted-foreground hover:text-red-400 transition-colors flex items-center gap-1 min-h-[36px]"
-            >
-              <Square className="w-3 h-3" />
-              {t("dm_stop_ambient")}
-            </button>
+        {activeLoops.length > 0 && (
+          <div className="mt-2">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-xs font-medium text-emerald-400">
+                🎵 {t("now_playing_count", { count: activeLoops.length })}
+              </span>
+              <button
+                type="button"
+                onClick={() => { stopAllAudio(); onBroadcast?.("audio:ambient_stop", {}); }}
+                className="text-xs text-muted-foreground hover:text-red-400 transition-colors flex items-center gap-1 min-h-[36px]"
+              >
+                <Square className="w-3 h-3" />
+                {t("dm_stop_all")}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {activeLoops.map((loop) => (
+                <span
+                  key={loop.id}
+                  className="inline-flex items-center gap-1 bg-emerald-500/15 border border-emerald-500/30 text-emerald-400 rounded-full px-2 py-0.5 text-xs"
+                >
+                  {loop.icon} {t(`preset_${loop.label?.replace("ambient-", "ambient_").replace("music-", "music_")}` as Parameters<typeof t>[0])}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      stopLoop(loop.id);
+                      onBroadcast?.("audio:loop_stop", { sound_id: loop.id });
+                    }}
+                    className="hover:text-red-400 transition-colors"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
           </div>
         )}
       </div>
@@ -163,7 +182,7 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
         type="button"
         onClick={() => setIsOpen((v) => !v)}
         className={`px-2 py-2 text-sm min-h-[44px] min-w-[44px] inline-flex items-center justify-center rounded-md transition-colors ${
-          isOpen || activeAmbientId
+          isOpen || activeLoops.length > 0
             ? "text-emerald-400 bg-emerald-500/10"
             : "text-muted-foreground hover:text-foreground"
         }`}
@@ -171,7 +190,7 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
         title={t("dm_soundboard")}
       >
         <Volume2 className="w-4 h-4" />
-        {activeAmbientId && (
+        {activeLoops.length > 0 && (
           <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-emerald-400 animate-pulse" />
         )}
       </button>
@@ -188,7 +207,7 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
             {/* Header */}
             <div className="flex items-center justify-between mb-3">
               <h3 className="text-foreground text-sm font-semibold">{t("dm_soundboard")}</h3>
-              {(activeAmbientId) && (
+              {activeLoops.length > 0 && (
                 <button
                   type="button"
                   onClick={handleStopAll}
@@ -200,13 +219,44 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
               )}
             </div>
 
+            {/* Now Playing chips */}
+            {activeLoops.length > 0 && (
+              <div className="mb-3">
+                <div className="flex items-center mb-1.5">
+                  <span className="text-xs font-medium text-emerald-400">
+                    🎵 {t("now_playing_count", { count: activeLoops.length })}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {activeLoops.map((loop) => (
+                    <span
+                      key={loop.id}
+                      className="inline-flex items-center gap-1 bg-emerald-500/15 border border-emerald-500/30 text-emerald-400 rounded-full px-2 py-0.5 text-[10px]"
+                    >
+                      {loop.icon} {t(`preset_${loop.label?.replace("ambient-", "ambient_").replace("music-", "music_")}` as Parameters<typeof t>[0])}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          stopLoop(loop.id);
+                          onBroadcast?.("audio:loop_stop", { sound_id: loop.id });
+                        }}
+                        className="hover:text-red-400 transition-colors"
+                      >
+                        <X className="w-2.5 h-2.5" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
             {/* Ambient Section */}
             <h4 className="text-muted-foreground text-xs font-medium mb-2 uppercase tracking-wider">
               {t("dm_ambient_section")}
             </h4>
             <div className="grid grid-cols-3 gap-2 mb-1">
               {ambientPresets.map((preset) => {
-                const isActive = activeAmbientId === preset.id;
+                const isActive = isLoopActive(preset.id);
                 return (
                   <button
                     key={preset.id}
@@ -230,34 +280,13 @@ export function DmSoundboard({ onBroadcast, ambientOnly = false }: DmSoundboardP
               })}
             </div>
 
-            {/* Active ambient indicator */}
-            {activeAmbientId && (
-              <div className="flex items-center justify-between mb-3 mt-1 px-1">
-                <span className="text-xs text-emerald-400">
-                  {t("dm_ambient_playing", {
-                    name: t(
-                      `preset_${activeAmbientId.replace("ambient-", "ambient_")}` as Parameters<typeof t>[0]
-                    ),
-                  })}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => { stopAmbient(); onBroadcast?.("audio:ambient_stop", {}); }}
-                  className="text-xs text-muted-foreground hover:text-red-400 transition-colors flex items-center gap-1"
-                >
-                  <Square className="w-3 h-3" />
-                  {t("dm_stop_ambient")}
-                </button>
-              </div>
-            )}
-
             {/* Music Section */}
             <h4 className="text-muted-foreground text-xs font-medium mb-2 mt-3 uppercase tracking-wider">
               {t("dm_music_section")}
             </h4>
             <div className="grid grid-cols-3 gap-2 mb-3">
               {musicPresets.map((preset) => {
-                const isActive = activeAmbientId === preset.id;
+                const isActive = isLoopActive(preset.id);
                 return (
                   <button
                     key={preset.id}

--- a/components/dashboard/SoundboardPageClient.tsx
+++ b/components/dashboard/SoundboardPageClient.tsx
@@ -10,7 +10,7 @@ import {
   getSfxPresets,
 } from "@/lib/utils/audio-presets";
 import { useAudioStore } from "@/lib/stores/audio-store";
-import { Play, Square } from "lucide-react";
+import { Play, Square, X } from "lucide-react";
 
 type PresetTab = "ambient" | "music" | "sfx";
 
@@ -21,8 +21,11 @@ export function SoundboardPageClient({ title }: { title: string }) {
   const [loading, setLoading] = useState(true);
   const [presetTab, setPresetTab] = useState<PresetTab>("ambient");
 
-  const activeAmbientId = useAudioStore((s) => s.activeAmbientId);
+  const isLoopActive = useAudioStore((s) => s.isLoopActive);
+  const activeLoops = useAudioStore((s) => s.activeLoops);
   const playAmbient = useAudioStore((s) => s.playAmbient);
+  const stopLoop = useAudioStore((s) => s.stopLoop);
+  const stopAllAudio = useAudioStore((s) => s.stopAllAudio);
   const playSound = useAudioStore((s) => s.playSound);
 
   const ambientPresets = getAmbientPresets();
@@ -132,10 +135,46 @@ export function SoundboardPageClient({ title }: { title: string }) {
           ))}
         </div>
 
+        {/* Now Playing bar */}
+        {activeLoops.length > 0 && (
+          <div className="bg-emerald-500/10 border border-emerald-500/20 rounded-lg p-3 mb-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs font-medium text-emerald-400">
+                🎵 {tAudio("now_playing_count", { count: activeLoops.length })}
+              </span>
+              <button
+                type="button"
+                onClick={() => stopAllAudio()}
+                className="text-xs text-muted-foreground hover:text-red-400 transition-colors flex items-center gap-1 min-h-[28px] px-2"
+              >
+                <Square className="w-3 h-3" />
+                {tAudio("dm_stop_all")}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {activeLoops.map((loop) => (
+                <span
+                  key={loop.id}
+                  className="inline-flex items-center gap-1.5 bg-emerald-500/15 border border-emerald-500/30 text-emerald-400 rounded-full px-2.5 py-1 text-xs"
+                >
+                  {loop.icon} {tAudio(`preset_${loop.label?.replace("ambient-", "ambient_").replace("music-", "music_")}` as Parameters<typeof tAudio>[0])}
+                  <button
+                    type="button"
+                    onClick={() => stopLoop(loop.id)}
+                    className="hover:text-red-400 transition-colors ml-0.5"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Preset grid */}
         <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
           {presetsByTab[presetTab].map((preset) => {
-            const isActive = activeAmbientId === preset.id;
+            const isActive = isLoopActive(preset.id);
             const isSfx = presetTab === "sfx";
 
             return (

--- a/components/dashboard/SoundboardPageClient.tsx
+++ b/components/dashboard/SoundboardPageClient.tsx
@@ -27,6 +27,7 @@ export function SoundboardPageClient({ title }: { title: string }) {
   const stopLoop = useAudioStore((s) => s.stopLoop);
   const stopAllAudio = useAudioStore((s) => s.stopAllAudio);
   const playSound = useAudioStore((s) => s.playSound);
+  const activeAudioId = useAudioStore((s) => s.activeAudioId);
 
   const ambientPresets = getAmbientPresets();
   const musicPresets = getMusicPresets();
@@ -113,9 +114,21 @@ export function SoundboardPageClient({ title }: { title: string }) {
 
       {/* ── Presets Section ── */}
       <section className="bg-card rounded-lg border border-border p-5">
-        <h2 className="text-foreground font-semibold text-sm uppercase tracking-wider mb-4 flex items-center gap-2">
-          🎵 {t("presets")}
-        </h2>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-foreground font-semibold text-sm uppercase tracking-wider flex items-center gap-2">
+            🎵 {t("presets")}
+          </h2>
+          {(activeLoops.length > 0 || activeAudioId) && (
+            <button
+              type="button"
+              onClick={() => stopAllAudio()}
+              className="text-xs text-muted-foreground hover:text-red-400 transition-colors flex items-center gap-1 min-h-[28px] px-2"
+            >
+              <Square className="w-3 h-3" />
+              {tAudio("dm_stop_all")}
+            </button>
+          )}
+        </div>
 
         {/* Preset tabs */}
         <div className="flex gap-2 mb-4">

--- a/components/dashboard/SoundboardPageClient.tsx
+++ b/components/dashboard/SoundboardPageClient.tsx
@@ -73,9 +73,21 @@ export function SoundboardPageClient({ title }: { title: string }) {
 
   return (
     <div className="max-w-3xl space-y-6">
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground mb-1">{title}</h1>
-        <p className="text-muted-foreground text-sm">{t("description")}</p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground mb-1">{title}</h1>
+          <p className="text-muted-foreground text-sm">{t("description")}</p>
+        </div>
+        {(activeLoops.length > 0 || activeAudioId) && (
+          <button
+            type="button"
+            onClick={() => stopAllAudio()}
+            className="shrink-0 mt-1 px-3 py-2 text-xs font-medium text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg hover:bg-red-500/20 transition-colors flex items-center gap-1.5 min-h-[36px]"
+          >
+            <Square className="w-3.5 h-3.5" />
+            {tAudio("dm_stop_all")}
+          </button>
+        )}
       </div>
 
       {/* ── Custom Sounds Section ── */}

--- a/components/player/PlayerJoinClient.tsx
+++ b/components/player/PlayerJoinClient.tsx
@@ -569,8 +569,14 @@ export function PlayerJoinClient({
           }
         })
         .on("broadcast", { event: "audio:ambient_stop" }, () => {
-          // DM stopped ambient/music — stop it on the player side
+          // DM stopped all ambient/music — stop all on the player side
           useAudioStore.getState().stopAmbient();
+        })
+        .on("broadcast", { event: "audio:loop_stop" }, ({ payload }) => {
+          // DM stopped a single loop — stop just that one on the player side
+          if (payload.sound_id) {
+            useAudioStore.getState().stopLoop(payload.sound_id);
+          }
         })
         .on("broadcast", { event: "combat:started" }, ({ payload }) => {
           setActive(true);

--- a/lib/stores/audio-store.ts
+++ b/lib/stores/audio-store.ts
@@ -23,6 +23,13 @@ function loadMuted(): boolean {
   return localStorage.getItem(LS_MUTED_KEY) === "true";
 }
 
+interface ActiveLoop {
+  id: string;
+  audio: HTMLAudioElement;
+  icon?: string;
+  label?: string;
+}
+
 interface AudioState {
   volume: number;
   isMuted: boolean;
@@ -30,7 +37,10 @@ interface AudioState {
   activeAudio: HTMLAudioElement | null;
   lastSoundLabel: string | null;
 
-  /** Ambient loop state */
+  /** Multiple active ambient/music loops */
+  activeLoops: ActiveLoop[];
+
+  /** Legacy getter — returns first active loop id (backward compat) */
   activeAmbientId: string | null;
   activeAmbientAudio: HTMLAudioElement | null;
 
@@ -41,9 +51,12 @@ interface AudioState {
   setVolume: (volume: number) => void;
   toggleMute: () => void;
   playSound: (soundId: string, source: "preset" | "custom", playerName: string, url?: string) => void;
+  /** Toggle a loop on/off. Supports multiple simultaneous loops. */
   playAmbient: (presetId: string) => void;
   stopAmbient: () => void;
+  stopLoop: (presetId: string) => void;
   stopAllAudio: () => void;
+  isLoopActive: (presetId: string) => boolean;
   preloadPlayerAudio: (audioFiles: PlayerAudioFile[]) => Promise<void>;
   cleanup: () => void;
 }
@@ -54,6 +67,7 @@ export const useAudioStore = create<AudioState>((set, get) => ({
   activeAudioId: null,
   activeAudio: null,
   lastSoundLabel: null,
+  activeLoops: [],
   activeAmbientId: null,
   activeAmbientAudio: null,
   playerAudioUrls: {},
@@ -63,58 +77,55 @@ export const useAudioStore = create<AudioState>((set, get) => ({
     const clamped = Math.max(0, Math.min(1, volume));
     set({ volume: clamped });
     localStorage.setItem(LS_VOLUME_KEY, String(clamped));
-    const { activeAudio, activeAmbientAudio, isMuted } = get();
+    const { activeAudio, activeLoops, isMuted } = get();
     const effectiveVol = isMuted ? 0 : clamped;
     if (activeAudio) activeAudio.volume = effectiveVol;
-    if (activeAmbientAudio) activeAmbientAudio.volume = effectiveVol;
+    for (const loop of activeLoops) {
+      loop.audio.volume = effectiveVol;
+    }
   },
 
   toggleMute: () => {
     const next = !get().isMuted;
     set({ isMuted: next });
     localStorage.setItem(LS_MUTED_KEY, String(next));
-    const { activeAudio, activeAmbientAudio, volume } = get();
+    const { activeAudio, activeLoops, volume } = get();
     const effectiveVol = next ? 0 : volume;
     if (activeAudio) activeAudio.volume = effectiveVol;
-    if (activeAmbientAudio) activeAmbientAudio.volume = effectiveVol;
+    for (const loop of activeLoops) {
+      loop.audio.volume = effectiveVol;
+    }
   },
 
   playSound: (soundId, source, playerName, url) => {
     const { isMuted, volume, activeAudio } = get();
     if (isMuted) return;
 
-    // Stop any currently playing audio
+    // Stop any currently playing one-shot
     if (activeAudio) {
       activeAudio.pause();
       activeAudio.currentTime = 0;
     }
 
-    // Resolve URL
     let audioUrl: string | undefined;
     if (source === "preset") {
       const preset = getPresetById(soundId);
       if (!preset) return;
       audioUrl = preset.file;
     } else {
-      // Custom: use provided URL or try preloaded
       audioUrl = url ?? get().playerAudioUrls[soundId];
     }
     if (!audioUrl) return;
 
-    // Check if we have a preloaded audio element
     const preloaded = get().preloadedAudio[soundId];
     const audio = preloaded ?? new Audio(audioUrl);
     audio.volume = volume;
     audio.currentTime = 0;
+    audio.loop = false;
 
-    // Ambient sounds loop continuously
+    audio.play().catch(() => {});
+
     const preset = source === "preset" ? getPresetById(soundId) : null;
-    audio.loop = preset?.category === "ambient" || preset?.category === "music";
-
-    audio.play().catch(() => {
-      // Browser blocked autoplay — ignored silently
-    });
-
     const label = `${playerName}: ${preset?.icon ?? "🔊"} ${preset?.id ?? soundId}`;
 
     set({
@@ -123,39 +134,26 @@ export const useAudioStore = create<AudioState>((set, get) => ({
       lastSoundLabel: label,
     });
 
-    // Clear active state when audio ends
     audio.onended = () => {
       set({ activeAudioId: null, activeAudio: null });
     };
   },
 
   playAmbient: (presetId) => {
-    const { activeAmbientId, activeAmbientAudio, isMuted, volume } = get();
+    const { activeLoops, isMuted, volume } = get();
 
-    // Toggle off if same ambient
-    if (activeAmbientId === presetId) {
-      if (activeAmbientAudio) {
-        activeAmbientAudio.pause();
-        activeAmbientAudio.currentTime = 0;
-      }
-      set({ activeAmbientId: null, activeAmbientAudio: null });
+    // Toggle off if already active
+    const existing = activeLoops.find((l) => l.id === presetId);
+    if (existing) {
+      existing.audio.pause();
+      existing.audio.currentTime = 0;
+      const newLoops = activeLoops.filter((l) => l.id !== presetId);
+      set({
+        activeLoops: newLoops,
+        activeAmbientId: newLoops[0]?.id ?? null,
+        activeAmbientAudio: newLoops[0]?.audio ?? null,
+      });
       return;
-    }
-
-    // Stop current ambient with quick fade
-    if (activeAmbientAudio) {
-      const old = activeAmbientAudio;
-      // Quick fade out (300ms)
-      const fadeStep = 0.05;
-      const fadeInterval = setInterval(() => {
-        if (old.volume > fadeStep) {
-          old.volume -= fadeStep;
-        } else {
-          clearInterval(fadeInterval);
-          old.pause();
-          old.currentTime = 0;
-        }
-      }, 20);
     }
 
     const preset = getPresetById(presetId);
@@ -166,39 +164,72 @@ export const useAudioStore = create<AudioState>((set, get) => ({
     audio.volume = isMuted ? 0 : volume;
     audio.play().catch(() => {});
 
+    const newLoop: ActiveLoop = {
+      id: presetId,
+      audio,
+      icon: preset.icon,
+      label: preset.id,
+    };
+    const newLoops = [...activeLoops, newLoop];
+
     set({
-      activeAmbientId: presetId,
-      activeAmbientAudio: audio,
+      activeLoops: newLoops,
+      activeAmbientId: newLoops[0]?.id ?? null,
+      activeAmbientAudio: newLoops[0]?.audio ?? null,
       lastSoundLabel: `${preset.icon} ${preset.id}`,
     });
   },
 
-  stopAmbient: () => {
-    const { activeAmbientAudio } = get();
-    if (activeAmbientAudio) {
-      activeAmbientAudio.pause();
-      activeAmbientAudio.currentTime = 0;
+  stopLoop: (presetId) => {
+    const { activeLoops } = get();
+    const loop = activeLoops.find((l) => l.id === presetId);
+    if (loop) {
+      loop.audio.pause();
+      loop.audio.currentTime = 0;
     }
-    set({ activeAmbientId: null, activeAmbientAudio: null });
+    const newLoops = activeLoops.filter((l) => l.id !== presetId);
+    set({
+      activeLoops: newLoops,
+      activeAmbientId: newLoops[0]?.id ?? null,
+      activeAmbientAudio: newLoops[0]?.audio ?? null,
+    });
+  },
+
+  stopAmbient: () => {
+    const { activeLoops } = get();
+    for (const loop of activeLoops) {
+      loop.audio.pause();
+      loop.audio.currentTime = 0;
+    }
+    set({ activeLoops: [], activeAmbientId: null, activeAmbientAudio: null });
   },
 
   stopAllAudio: () => {
-    const { activeAudio, activeAmbientAudio } = get();
+    const { activeAudio, activeLoops } = get();
     if (activeAudio) {
       activeAudio.pause();
       activeAudio.currentTime = 0;
     }
-    if (activeAmbientAudio) {
-      activeAmbientAudio.pause();
-      activeAmbientAudio.currentTime = 0;
+    for (const loop of activeLoops) {
+      loop.audio.pause();
+      loop.audio.currentTime = 0;
     }
-    set({ activeAudioId: null, activeAudio: null, activeAmbientId: null, activeAmbientAudio: null });
+    set({
+      activeAudioId: null,
+      activeAudio: null,
+      activeLoops: [],
+      activeAmbientId: null,
+      activeAmbientAudio: null,
+    });
+  },
+
+  isLoopActive: (presetId) => {
+    return get().activeLoops.some((l) => l.id === presetId);
   },
 
   preloadPlayerAudio: async (audioFiles) => {
     if (audioFiles.length === 0) return;
 
-    // Clean up existing preloaded audio for the same IDs to prevent memory leaks
     const existing = get().preloadedAudio;
     for (const file of audioFiles) {
       const old = existing[file.id];
@@ -216,7 +247,7 @@ export const useAudioStore = create<AudioState>((set, get) => ({
       try {
         const { data } = await supabase.storage
           .from("player-audio")
-          .createSignedUrl(file.file_path, 3600); // 1h expiry
+          .createSignedUrl(file.file_path, 3600);
 
         if (data?.signedUrl) {
           urls[file.id] = data.signedUrl;
@@ -226,7 +257,7 @@ export const useAudioStore = create<AudioState>((set, get) => ({
           preloaded[file.id] = audio;
         }
       } catch {
-        // Skip failed preloads — will fallback to on-demand
+        // Skip failed preloads
       }
     }
 
@@ -237,16 +268,15 @@ export const useAudioStore = create<AudioState>((set, get) => ({
   },
 
   cleanup: () => {
-    const { activeAudio, activeAmbientAudio, preloadedAudio } = get();
+    const { activeAudio, activeLoops, preloadedAudio } = get();
     if (activeAudio) {
       activeAudio.pause();
       activeAudio.currentTime = 0;
     }
-    if (activeAmbientAudio) {
-      activeAmbientAudio.pause();
-      activeAmbientAudio.currentTime = 0;
+    for (const loop of activeLoops) {
+      loop.audio.pause();
+      loop.audio.currentTime = 0;
     }
-    // Release preloaded audio elements
     Object.values(preloadedAudio).forEach((audio) => {
       audio.pause();
       audio.src = "";
@@ -254,6 +284,7 @@ export const useAudioStore = create<AudioState>((set, get) => ({
     set({
       activeAudioId: null,
       activeAudio: null,
+      activeLoops: [],
       activeAmbientId: null,
       activeAmbientAudio: null,
       playerAudioUrls: {},

--- a/lib/types/realtime.ts
+++ b/lib/types/realtime.ts
@@ -27,6 +27,7 @@ export type RealtimeEventType =
   | "audio:play_sound"
   | "audio:ambient_start"
   | "audio:ambient_stop"
+  | "audio:loop_stop"
   | "player:death_save";
 
 export interface RealtimeHpUpdate {
@@ -189,6 +190,11 @@ export interface RealtimeAmbientStop {
   type: "audio:ambient_stop";
 }
 
+export interface RealtimeLoopStop {
+  type: "audio:loop_stop";
+  sound_id: string;
+}
+
 export interface RealtimePlayerDeathSave {
   type: "player:death_save";
   player_name: string;
@@ -219,6 +225,7 @@ export type RealtimeEvent =
   | RealtimeAudioPlay
   | RealtimeAmbientStart
   | RealtimeAmbientStop
+  | RealtimeLoopStop
   | RealtimePlayerDeathSave;
 
 // ── Sanitized types for player-facing broadcast (A.0.6) ──────────
@@ -307,4 +314,5 @@ export type SanitizedEvent =
   | RealtimeWeatherChange
   | RealtimeAudioPlay
   | RealtimeAmbientStart
-  | RealtimeAmbientStop;
+  | RealtimeAmbientStop
+  | RealtimeLoopStop;

--- a/messages/en.json
+++ b/messages/en.json
@@ -1698,6 +1698,7 @@
     "dm_ambient_playing": "Playing: {name}",
     "dm_stop_ambient": "Stop",
     "dm_stop_all": "Stop All",
+    "now_playing_count": "Playing ({count})",
     "atmosphere_label": "Atmosphere",
     "dashboard_ambient_title": "Ambient Sounds",
     "slot_empty": "Empty slot",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1698,6 +1698,7 @@
     "dm_ambient_playing": "Tocando: {name}",
     "dm_stop_ambient": "Parar",
     "dm_stop_all": "Parar Tudo",
+    "now_playing_count": "Tocando ({count})",
     "atmosphere_label": "Atmosfera",
     "dashboard_ambient_title": "Sons Ambientes",
     "slot_empty": "Slot vazio",


### PR DESCRIPTION
## Summary

- **UX fixes**: move search FAB to header (mobile), unify settings pages, reduce mobile nav to 4 tabs
- **Campaign combat flow**: new combat launch sheet with 4 options (New Combat, Send Link, Quick Combat, Load Preset)
- **Soundboard redesign**: custom sound upload (5 MP3s, 5MB max, emoji picker), preset tabs (ambient/music/sfx)
- **Soundboard in hamburger menu**: mobile access via app layout menu (DM only)
- **Free audio layering**: multiple simultaneous ambient/music loops with individual stop controls
- **Broadcast sync**: new `audio:loop_stop` event for individual loop stop on player side
- **Now Playing bar**: active loops shown as chips with individual stop + "Stop All" in all 3 DM audio components

## Files changed (25)

- Store: `audio-store.ts` rewritten with `activeLoops[]`, `stopLoop`, `isLoopActive`
- UI: `SoundboardPageClient`, `DmAtmospherePanel`, `DmSoundboard` updated for multi-loop
- Broadcast: `realtime.ts` + `PlayerJoinClient.tsx` — new `audio:loop_stop` event
- New: `CombatLaunchSheet`, `CustomSoundCard`, `CustomSoundUploader`, `dm-audio` API route
- Migration: `049_dm_custom_sounds.sql` (table + storage bucket)
- i18n: 55+ new keys in pt-BR and en

## Test plan

- [ ] Toggle multiple ambient/music presets simultaneously — all should play
- [ ] Click × on individual chip — only that loop stops, others continue
- [ ] Click "Stop All" — all loops stop
- [ ] Player side receives layered audio and individual stop events
- [ ] Custom sound upload: MP3 only, 5MB max, 5 sounds limit
- [ ] Campaign combat launch sheet: 4 options render correctly
- [ ] Mobile: search icon in header, 4-tab nav, soundboard in hamburger menu

https://claude.ai/code/session_015tcdtdJqcmTm2MRvkAtmov