### PR TITLE
feat(grimório): add PLAYER_HQ_V2 feature flag library (EP-INFRA.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,25 @@ VAPID_SUBJECT=mailto:noreply@pocketdm.com.br
 # automatically when running E2E locally.
 NEXT_PUBLIC_E2E_MODE=false
 
+# ── Grimório / Player HQ V2 redesign feature flag (see lib/flags/player-hq-v2.ts) ──
+# Gates the 4-tab Player HQ redesign (Herói/Arsenal/Diário/Mapa) and all
+# conversion/journey surfaces that will read it from Sprint 2 onward.
+#
+# Strict compare: ONLY the exact string "true" (lowercase) enables the flag.
+# Any other value — "1", "yes", empty, unset, typo — resolves to OFF. This
+# mirrors NEXT_PUBLIC_E2E_MODE and is intentional: a typo can never flip V2
+# on in prod accidentally.
+#
+# Recommended Vercel settings:
+#   Production:  NEXT_PUBLIC_PLAYER_HQ_V2=false   (until Sprint 10 flag flip)
+#   Preview:     NEXT_PUBLIC_PLAYER_HQ_V2=true    (continuous V2 QA)
+#   Staging:     NEXT_PUBLIC_PLAYER_HQ_V2=true    (continuous V2 QA)
+#   Development: NEXT_PUBLIC_PLAYER_HQ_V2=true    (agent worktrees work on V2)
+#
+# Timeline: Sprint 10 deletes this flag + `lib/flags/player-hq-v2.ts` together.
+# See docs/feature-flags.md and _bmad-output/party-mode-2026-04-22/14-sprint-plan.md §2.
+NEXT_PUBLIC_PLAYER_HQ_V2=false
+
 # ── Beta 3 remediation feature flags (see lib/flags.ts) ──
 # Defaults to false. Flip to "1" (or "true") after the player-client soak
 # window has elapsed — see docs/sprint-plan-beta3-remediation.md S1.2 rollout.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,132 @@
+# Feature Flags Reference
+
+This repo uses three coexisting feature-flag systems. Pick the right one
+for the situation before adding a new toggle.
+
+| System | File | Purpose | Storage |
+|---|---|---|---|
+| Env-driven beta rollouts | [`lib/flags.ts`](../lib/flags.ts) | Architecture-change rollouts (e.g. `ff_combatant_add_reorder`) with `window.__RPG_FLAGS__` runtime override for tests | `process.env.NEXT_PUBLIC_FF_*` + hard-coded defaults + runtime override |
+| Plan / subscription gating | [`lib/feature-flags.ts`](../lib/feature-flags.ts) | Features tied to user plan (`free` vs `pro`) | Supabase table (server-resolved) |
+| Single-purpose redesign flags | `lib/flags/*` | One file per large surface redesign (current: Grimório / Player HQ V2) | `process.env.NEXT_PUBLIC_*` with strict compare |
+
+The "single-purpose" folder is intentional so Sprint-10-style cleanup
+is a clean file delete + grep-replace, without touching the shared
+`lib/flags.ts` enum every time a redesign lands.
+
+---
+
+## `NEXT_PUBLIC_PLAYER_HQ_V2` — Grimório / Player HQ V2
+
+**Module:** [`lib/flags/player-hq-v2.ts`](../lib/flags/player-hq-v2.ts)
+**Owner:** Grimório workstream (Track A + Track B, Sprint 1–10)
+**Spec:** [`_bmad-output/party-mode-2026-04-22/14-sprint-plan.md §2`](../_bmad-output/party-mode-2026-04-22/14-sprint-plan.md)
+**PRD decisions:** [`_bmad-output/party-mode-2026-04-22/PRD-EPICO-CONSOLIDADO.md`](../_bmad-output/party-mode-2026-04-22/PRD-EPICO-CONSOLIDADO.md) decisions #27–#47
+
+### What it gates (once Sprint 2+ adds call sites)
+
+All surfaces that make up the 4-tab Player HQ redesign:
+
+- `components/player/PlayerHqShell.tsx` — 4-tab shell (Herói / Arsenal / Diário / Mapa) vs. current 7-tab sheet
+- `/app/campaigns/[id]/sheet` route — rendering path picks V1 or V2 shell by flag
+- `/app/campaigns/[id]/journey` — new route only exists when flag ON
+- 3 conversion components that redirect post-combat per decision #43:
+  - `components/conversion/RecapCtaCard.tsx` — flag ON redirects to `/sheet?tab=heroi`
+  - `components/conversion/GuestRecapFlow.tsx` — same
+  - `components/conversion/GuestUpsellModal.tsx` — same
+- Level Up wizard (Sprint 7–8 — gated by the same flag + optional sub-flag `NEXT_PUBLIC_LEVELUP_WIZARD`)
+
+### Strict-compare semantics
+
+Only the exact string `"true"` enables the flag. Any other value — `"1"`,
+`"yes"`, empty string, unset, a typo — resolves to `false`. This mirrors
+`NEXT_PUBLIC_E2E_MODE` and is intentional: a typo can never flip V2 on in
+prod accidentally.
+
+```ts
+// Correct
+NEXT_PUBLIC_PLAYER_HQ_V2=true    // → flag ON
+
+// All of these → flag OFF
+NEXT_PUBLIC_PLAYER_HQ_V2=True
+NEXT_PUBLIC_PLAYER_HQ_V2=1
+NEXT_PUBLIC_PLAYER_HQ_V2=yes
+NEXT_PUBLIC_PLAYER_HQ_V2=tru
+NEXT_PUBLIC_PLAYER_HQ_V2=
+// (unset)
+```
+
+### Recommended Vercel configuration
+
+| Environment | Value | Rationale |
+|---|---|---|
+| Production | `false` (or unset) | Master stays deployable through all 8 dev sprints; users see V1 until Sprint 10 flip |
+| Preview (PR deploys) | `true` | Every PR is tested against V2 automatically |
+| Staging | `true` | Continuous V2 QA for Dani and QA leads |
+| Development (local + agent worktrees) | `true` | Dev work happens on V2 by default |
+
+Set these via Vercel → Project → Settings → Environment Variables. Scope
+each value to the matching environment.
+
+### Local development
+
+Copy `.env.example` → `.env.local` and set:
+
+```
+NEXT_PUBLIC_PLAYER_HQ_V2=true
+```
+
+Then restart `next dev` — Next.js inlines `NEXT_PUBLIC_*` vars at build
+time, so env changes do NOT hot-reload.
+
+### Usage in code
+
+```ts
+import { isPlayerHqV2Enabled } from "@/lib/flags/player-hq-v2";
+
+// In a server component, route handler, or client component
+if (isPlayerHqV2Enabled()) {
+  return <PlayerHqShell campaignId={id} />;
+}
+return <LegacyPlayerSheet campaignId={id} />;
+```
+
+Do not call the function at module top-level if you need SSR+CSR consistency —
+call it inside a component/handler so both environments evaluate the same
+inlined value.
+
+### Rollout timeline
+
+| Sprint | Track A owns | Track B owns | Flag state |
+|---|---|---|---|
+| 1 | EP-0 consolidations | Flag lib + CI parity + E2E scaffold | OFF everywhere (no call sites yet) |
+| 2 | A1–A6 (Fase A quick wins) | A6 conversion rewrites + post-combat redirect | OFF prod / ON staging |
+| 3–4 | B1–B6 (Fase B topologia 4 tabs) | Tab state hook + Wave 3 scaffolds | OFF prod / ON staging |
+| 5–6 | C1–C7 (Ribbon Vivo + Combat Auto) | D1+E1 migrations + Diário + 5e unit tests | OFF prod / ON staging |
+| 7–8 | E4–E6 (Wizard Level Up) | E2/E7 Mestre UI + polish | OFF prod / ON staging |
+| 9 | QA/regression + bug bash | QA + prod migration deploy | OFF prod / ON staging |
+| 10 | **Flip ON prod** (10 % → 50 % → 100 % Tue/Wed/Thu) | Retrospective + post-flip monitoring | **ON everywhere** |
+| 10 (Fri) | **Cleanup PR** — delete flag, delete V1 code | Same | Flag deleted |
+
+### Sprint 10 cleanup checklist
+
+1. `rtk grep "NEXT_PUBLIC_PLAYER_HQ_V2"` — list every call site
+2. Replace every `if (isPlayerHqV2Enabled())` branch with the V2 path
+3. Delete:
+   - `lib/flags/player-hq-v2.ts`
+   - `lib/flags/player-hq-v2.test.ts`
+   - V1 files (old sheet shell, old conversion redirect branches)
+   - `.env.example` section and Vercel env vars
+   - This subsection of `docs/feature-flags.md`
+4. Verify `rtk tsc --noEmit` + `rtk lint` clean
+5. Open `chore/hq-v2-cleanup` PR on Friday of Sprint 10
+
+### Do NOT
+
+- Use `NEXT_PUBLIC_PLAYER_HQ_V4` — legacy doc-only name. Grep 2026-04-23
+  showed zero code references; standardized on V2 per Dani directive.
+- Extend `lib/flags.ts` enum for this — the single-purpose file keeps
+  cleanup trivial.
+- Call `isPlayerHqV2Enabled()` inside `useMemo` deps or similar reactive
+  contexts — it is a constant per deploy, not reactive.
+- Flip the prod flag before the Sprint 9 QA gate closes — rollout cadence
+  is authorized by Dani only.

--- a/lib/flags/player-hq-v2.test.ts
+++ b/lib/flags/player-hq-v2.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for `lib/flags/player-hq-v2.ts` — Sprint 1 Track B (EP-INFRA.2).
+ *
+ * Verifies strict-compare semantics: only the exact string `"true"` flips
+ * the flag. Any other value (including truthy-ish strings like "1" or "yes",
+ * empty string, undefined, or a typo) MUST resolve to `false`. Strict compare
+ * protects prod — a typo like `NEXT_PUBLIC_PLAYER_HQ_V2=tru` can never flip
+ * the V2 surface on accidentally.
+ */
+
+import { PLAYER_HQ_V2_FLAG, isPlayerHqV2Enabled } from "./player-hq-v2";
+
+describe("lib/flags/player-hq-v2 — PLAYER_HQ_V2_FLAG", () => {
+  test("exports the canonical env var name", () => {
+    expect(PLAYER_HQ_V2_FLAG).toBe("NEXT_PUBLIC_PLAYER_HQ_V2");
+  });
+});
+
+describe("lib/flags/player-hq-v2 — isPlayerHqV2Enabled", () => {
+  const ENV_KEY = "NEXT_PUBLIC_PLAYER_HQ_V2";
+  const envRef = process.env as Record<string, string | undefined>;
+  const originalValue = envRef[ENV_KEY];
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete envRef[ENV_KEY];
+    } else {
+      envRef[ENV_KEY] = originalValue;
+    }
+  });
+
+  test("returns false when env var is undefined", () => {
+    delete envRef[ENV_KEY];
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns false when env var is empty string", () => {
+    envRef[ENV_KEY] = "";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns true ONLY for exact string 'true'", () => {
+    envRef[ENV_KEY] = "true";
+    expect(isPlayerHqV2Enabled()).toBe(true);
+  });
+
+  test("returns false for 'True' (case-sensitive strict compare)", () => {
+    envRef[ENV_KEY] = "True";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns false for 'TRUE' (case-sensitive strict compare)", () => {
+    envRef[ENV_KEY] = "TRUE";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns false for '1' (strict compare — not truthy-ish)", () => {
+    envRef[ENV_KEY] = "1";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns false for 'yes' (strict compare — not truthy-ish)", () => {
+    envRef[ENV_KEY] = "yes";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns false for 'false'", () => {
+    envRef[ENV_KEY] = "false";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns false for arbitrary typo 'tru'", () => {
+    envRef[ENV_KEY] = "tru";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+
+  test("returns false for trailing-whitespace variant ' true '", () => {
+    envRef[ENV_KEY] = " true ";
+    expect(isPlayerHqV2Enabled()).toBe(false);
+  });
+});

--- a/lib/flags/player-hq-v2.ts
+++ b/lib/flags/player-hq-v2.ts
@@ -1,0 +1,51 @@
+/**
+ * Player HQ V2 (Grimório) feature flag — Sprint 1 Track B (EP-INFRA.2).
+ *
+ * Gates the 4-tab Player HQ redesign (Herói/Arsenal/Diário/Mapa) and all
+ * downstream conversion + journey surfaces that will start reading it from
+ * Sprint 2 onward. Flag stays OFF in prod through Sprint 9; flips ON in
+ * Sprint 10 (MVP flag flip). While OFF, master remains deployable and
+ * users see the existing V1 Player HQ (7-tab sheet).
+ *
+ * Naming rationale: the sprint plan and PRD initially referenced
+ * `NEXT_PUBLIC_PLAYER_HQ_V4` (matching redesign-proposal v0.4). Grep on
+ * 2026-04-23 (Sprint 1 Day 1 Task 0) showed zero hits in code — only doc
+ * mentions. Per Dani directive we standardize on V2 fresh; docs listing
+ * V4 will be updated separately. See `_bmad-output/party-mode-2026-04-22/
+ * 14-sprint-plan.md §2` and `§10 Go/no-go`.
+ *
+ * Usage (to begin Sprint 2):
+ *   import { isPlayerHqV2Enabled, PLAYER_HQ_V2_FLAG } from "@/lib/flags/player-hq-v2";
+ *   if (isPlayerHqV2Enabled()) { ...render new 4-tab shell... }
+ *
+ * Timeline: Sprint 10 deletes this file together with all call sites.
+ * See `docs/feature-flags.md` for rollout + cleanup plan.
+ *
+ * Distinct from:
+ *   - `lib/flags.ts`            — env-driven beta rollout flags (shared keys).
+ *   - `lib/feature-flags.ts`    — Supabase-backed subscription/plan flags.
+ * This file is a dedicated single-purpose module for the Grimório rollout
+ * so Sprint 10 cleanup is a trivial file delete + grep replace.
+ */
+
+/**
+ * Canonical env-var name. Exported so tests, docs, CI guards, and the
+ * Sprint 10 cleanup grep can reference a single source of truth instead
+ * of hard-coding the string.
+ */
+export const PLAYER_HQ_V2_FLAG = "NEXT_PUBLIC_PLAYER_HQ_V2" as const;
+
+/**
+ * Returns `true` only when `NEXT_PUBLIC_PLAYER_HQ_V2` equals the exact
+ * string `"true"`. Any other value (`"1"`, `"yes"`, unset, empty, typo)
+ * resolves to `false`. The strict compare mirrors the convention used
+ * by `NEXT_PUBLIC_E2E_MODE` (see `.env.example`): risky rollouts demand
+ * a single unambiguous opt-in value so staging/prod can never enable
+ * the flag by accident via a truthy-ish string.
+ *
+ * Safe to call from both server and client (Next.js inlines the
+ * `NEXT_PUBLIC_*` var at build time for the client bundle).
+ */
+export function isPlayerHqV2Enabled(): boolean {
+  return process.env.NEXT_PUBLIC_PLAYER_HQ_V2 === "true";
+}


### PR DESCRIPTION
## Summary

Sprint 1 Track B — Infrastructure for the Grimório (Player HQ V2 redesign) rollout.

Creates the feature-flag scaffolding that Track A and Waves 2–4 will start consuming in Sprint 2+. **No-op in production**: no call sites yet, flag defaults to `false` everywhere except preview/staging (per Vercel env recommendation in `.env.example`).

## What's in this PR

- **`lib/flags/player-hq-v2.ts`** — single-purpose flag module with `isPlayerHqV2Enabled()` + `PLAYER_HQ_V2_FLAG` constant. Strict compare: only the exact string `"true"` enables the flag. Mirrors the `NEXT_PUBLIC_E2E_MODE` pattern so a typo (`"tru"`, `"True"`, `"1"`) can never flip V2 on accidentally.
- **`lib/flags/player-hq-v2.test.ts`** — 11 unit tests: undefined, empty, `"true"`, `"True"` (case-sensitive), `"TRUE"`, `"1"`, `"yes"`, `"false"`, typo `"tru"`, whitespace, constant export.
- **`.env.example`** — documented block with Vercel env recommendations (Prod=false, Preview/Staging/Dev=true).
- **`docs/feature-flags.md`** — NEW doc covering:
  - All three coexisting flag systems (env-driven beta / Supabase plan-gated / single-purpose redesign)
  - Rollout timeline Sprint 1 → Sprint 10 with who owns what per sprint
  - Sprint 10 cleanup checklist (delete flag + all V1 code in a single chore PR)
  - Usage examples + Vercel configuration matrix

## Task 0 — flag-name decision

Before writing any code, I ran the grep required by the Sprint 1 Go/no-go checklist (`14-sprint-plan.md §10`):

- `rtk grep "NEXT_PUBLIC_PLAYER_HQ_V4"` → **2 hits, both in `_bmad-output/*.md` docs only**. Zero hits in code.
- `rtk grep "NEXT_PUBLIC_PLAYER_HQ_V2"` → zero hits (clean slate).

Per the Sprint 1 playbook and Dani's directive, standardized on **V2 fresh**. The two doc references to V4 in `PRD-EPICO-CONSOLIDADO.md` + `09-implementation-plan.md` are out of scope for this PR and will be swept separately.

## Why the single-purpose file pattern

- `lib/flags.ts` already exists for architecture-rollout flags (`ff_*`). Adding `PLAYER_HQ_V2` there would couple our Sprint 10 cleanup to touching that enum.
- A dedicated module at `lib/flags/player-hq-v2.ts` makes Sprint 10 cleanup a trivial file delete + grep replace.
- See `docs/feature-flags.md` for the three-system breakdown.

## Test plan

- [x] `rtk tsc --noEmit` — clean
- [x] `rtk npm test -- --testPathPatterns="lib/flags/player-hq-v2" --ci` — 11/11 pass
- [x] `rtk npm run lint` — no new lint errors introduced (diff-scoped grep on output returns nothing)
- [x] Zero call sites in codebase → no runtime behavior change in prod
- [ ] Dani: verify Vercel env var matrix matches doc recommendation (optional, can defer to Sprint 2 when first call site lands)

## References

- `_bmad-output/party-mode-2026-04-22/14-sprint-plan.md §2` — feature flag contract
- `_bmad-output/party-mode-2026-04-22/14-sprint-plan.md §10` — Sprint 1 Go/no-go checklist
- `_bmad-output/party-mode-2026-04-22/PRD-EPICO-CONSOLIDADO.md` decisions #27–#47

Closes EP-INFRA.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)