### PR TITLE
feat(grimório): extract SpellSlotGrid primitive (EP-0 C0.2)

### DIFF
--- a/components/player-hq/SpellSlotsHq.tsx
+++ b/components/player-hq/SpellSlotsHq.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { Plus, Wand2, Pencil } from "lucide-react";
-import { ResourceDots } from "./ResourceDots";
+import { SpellSlotGrid } from "@/components/ui/SpellSlotGrid";
 
 interface SpellSlotsHqProps {
   spellSlots: Record<string, { max: number; used: number }> | null;
@@ -120,14 +120,15 @@ export function SpellSlotsHq({
                 {level}°
               </span>
               <div className="flex-1">
-                <ResourceDots
-                  usedCount={used}
+                <SpellSlotGrid
+                  used={used}
                   max={max}
-                  color="bg-amber-400 border-amber-400"
-                  size="md"
+                  variant="transient"
+                  density="comfortable"
+                  filledClassName="bg-amber-400 border-amber-400"
                   readOnly={readOnly}
                   onToggle={(idx) => handleToggle(level, idx)}
-                  label={`${t("spell_slots_level")} ${level}`}
+                  ariaLabel={`${t("spell_slots_level")} ${level}`}
                 />
               </div>
               {/* Inline max edit */}

--- a/components/player/SpellSlotTracker.tsx
+++ b/components/player/SpellSlotTracker.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { Moon } from "lucide-react";
+import { SpellSlotGrid } from "@/components/ui/SpellSlotGrid";
 
 interface SpellSlotTrackerProps {
   spellSlots: Record<string, { max: number; used: number }>;
@@ -21,25 +22,12 @@ export function SpellSlotTracker({
 }: SpellSlotTrackerProps) {
   const t = useTranslations("player");
   const [isExpanded, setIsExpanded] = useState(!collapsible);
-  const [bouncingDot, setBouncingDot] = useState<string | null>(null);
 
   const levels = Object.entries(spellSlots)
     .filter(([, v]) => v.max > 0)
     .sort(([a], [b]) => Number(a) - Number(b));
 
   if (levels.length === 0) return null;
-
-  const handleToggle = useCallback(
-    (level: string, index: number) => {
-      if (readOnly) return;
-      const dotKey = `${level}-${index}`;
-      setBouncingDot(dotKey);
-      setTimeout(() => setBouncingDot(null), 400);
-      navigator.vibrate?.([50]);
-      onToggleSlot(level, index);
-    },
-    [readOnly, onToggleSlot]
-  );
 
   const handleLongRest = useCallback(() => {
     if (readOnly) return;
@@ -101,28 +89,21 @@ export function SpellSlotTracker({
               <span className="text-[10px] text-muted-foreground w-6 shrink-0">
                 {level}°
               </span>
-              <div className="flex gap-1 flex-wrap">
-                {Array.from({ length: max }, (_, i) => {
-                  const isUsed = i >= max - used;
-                  const dotKey = `${level}-${i}`;
-                  return (
-                    <button
-                      key={i}
-                      type="button"
-                      role="checkbox"
-                      aria-checked={!isUsed}
-                      aria-label={`${t("spell_slots_level", { level })} slot ${i + 1}, ${isUsed ? t("spell_slots_used") : t("spell_slots_available")}`}
-                      onClick={() => handleToggle(level, i)}
-                      disabled={readOnly}
-                      className={`w-3 h-3 rounded-full border transition-transform duration-200 ${
-                        isUsed
-                          ? "bg-transparent border-muted-foreground/30"
-                          : "bg-purple-400 border-purple-400"
-                      } ${bouncingDot === dotKey ? "scale-[1.3]" : ""} ${readOnly ? "cursor-default" : "cursor-pointer hover:opacity-80"}`}
-                    />
-                  );
-                })}
-              </div>
+              <SpellSlotGrid
+                used={used}
+                max={max}
+                variant="transient"
+                density="compact"
+                filledClassName="bg-purple-400 border-purple-400"
+                readOnly={readOnly}
+                onToggle={(i) => onToggleSlot(level, i)}
+                ariaLabel={t("spell_slots_level", { level })}
+                dotAriaLabel={(i, isFilled) =>
+                  `${t("spell_slots_level", { level })} slot ${i + 1}, ${
+                    isFilled ? t("spell_slots_available") : t("spell_slots_used")
+                  }`
+                }
+              />
             </div>
           ))}
         </div>

--- a/components/ui/SpellSlotGrid.tsx
+++ b/components/ui/SpellSlotGrid.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * SpellSlotGrid — EP-0 C0.2 consolidation primitive.
+ *
+ * Shared dot-grid UI for a single spell-slot level row. Extracted from
+ * `components/player-hq/SpellSlotsHq.tsx` (HQ variant, via `ResourceDots`)
+ * and `components/player/SpellSlotTracker.tsx` (combat variant) to remove
+ * duplication before Wave 1–4 features land.
+ *
+ * ## Behavior contract (do NOT change)
+ *
+ * - Click a dot to toggle it. The `onToggle(index)` callback receives the
+ *   zero-based dot index the user clicked. Hosts translate the index into
+ *   a `used` count exactly as they do today.
+ * - For `variant="transient"` (today's only real caller) the filled state
+ *   is **filled dot = slot available**. That is,
+ *   `isFilled = i < (max - used)`. This matches the legacy `ResourceDots`
+ *   and combat `SpellSlotTracker` behavior bit-for-bit.
+ * - For `variant="permanent"` the filled state is **filled dot = acquired**.
+ *   No existing spell-slot caller uses this variant; the prop exists so
+ *   PRD decision #37 can flip semantics behind a flag later.
+ *
+ * ## What this component does NOT do
+ *
+ * - Does not flip the visual semantic of transient resources (Sprint 5,
+ *   behind `NEXT_PUBLIC_PLAYER_HQ_V2`).
+ * - Does not render headers, "Long rest" buttons, or "+ add level" CTAs —
+ *   host components keep those responsibilities.
+ * - Does not invent tiers or labels — callers pass `ariaLabel` verbatim.
+ *
+ * ## Density presets
+ *
+ * - `density="comfortable"` (default; HQ) — 14px dots, 0.5 gap, 44×44
+ *   invisible touch padding per WCAG 2.1 SC 2.5.5.
+ * - `density="compact"` — 12px dots, 1-unit gap, no touch padding. Used by
+ *   the combat `SpellSlotTracker` which must fit into a crowded row.
+ */
+
+import { useCallback, useState } from "react";
+
+/** Variant drives the semantic of `isFilled` (see doc comment). */
+export type SpellSlotGridVariant = "permanent" | "transient";
+
+/** Density preset — see doc comment. */
+export type SpellSlotGridDensity = "comfortable" | "compact";
+
+export interface SpellSlotGridProps {
+  /** Slots consumed this long rest. Mirrors today's `slot.used` prop. */
+  used: number;
+  /** Slot pool for this level. Render exactly `max` dots. */
+  max: number;
+  /**
+   * Semantic of the filled state.
+   * - `transient`: filled dot = available slot (legacy behavior).
+   * - `permanent`: filled dot = acquired (reserved for future consumers).
+   */
+  variant: SpellSlotGridVariant;
+  /**
+   * Click handler. Receives the zero-based dot index. Hosts decide how the
+   * index maps to an increment/decrement on `used`.
+   */
+  onToggle?: (index: number) => void;
+  /**
+   * Density preset; defaults to `comfortable` (the HQ default).
+   */
+  density?: SpellSlotGridDensity;
+  /**
+   * Tailwind classes applied to the filled dot (background + border).
+   * Defaults to the HQ amber palette; the combat variant overrides to
+   * purple.
+   */
+  filledClassName?: string;
+  /** Disables the buttons and drops the hover/active affordances. */
+  readOnly?: boolean;
+  /** Accessible label for the whole group. Required for a11y. */
+  ariaLabel: string;
+  /**
+   * Optional label formatter per-dot (defaults to `${ariaLabel} ${i + 1}/${max}`).
+   * The combat variant uses richer per-dot labels so we expose this hook.
+   */
+  dotAriaLabel?: (index: number, isFilled: boolean) => string;
+}
+
+interface DensityStyles {
+  dot: string;
+  gap: string;
+  /** Non-empty means: wrap each dot in an invisible padded 44×44 hit area. */
+  touch: string;
+  empty: string;
+  bounceScale: string;
+}
+
+const DENSITY: Record<SpellSlotGridDensity, DensityStyles> = {
+  // HQ/ResourceDots md-equivalent — 14px dot, 44×44 invisible touch target.
+  comfortable: {
+    dot: "w-3.5 h-3.5",
+    gap: "gap-0.5",
+    touch: "p-1 min-w-[44px] min-h-[44px] flex items-center justify-center",
+    empty: "bg-white/[0.15] border-white/[0.08]",
+    bounceScale: "scale-125",
+  },
+  // Combat tracker — 12px dot, inline row, no padded hit area.
+  compact: {
+    dot: "w-3 h-3",
+    gap: "gap-1",
+    touch: "",
+    empty: "bg-transparent border-muted-foreground/30",
+    bounceScale: "scale-[1.3]",
+  },
+};
+
+export function SpellSlotGrid({
+  used,
+  max,
+  variant,
+  onToggle,
+  density = "comfortable",
+  filledClassName = "bg-amber-400 border-amber-400",
+  readOnly = false,
+  ariaLabel,
+  dotAriaLabel,
+}: SpellSlotGridProps) {
+  const [bouncingDot, setBouncingDot] = useState<number | null>(null);
+  const d = DENSITY[density];
+
+  const handleToggle = useCallback(
+    (index: number) => {
+      if (readOnly) return;
+      setBouncingDot(index);
+      setTimeout(() => setBouncingDot(null), 400);
+      navigator.vibrate?.([50]);
+      onToggle?.(index);
+    },
+    [readOnly, onToggle]
+  );
+
+  // transient → filled = remaining/available (legacy bit-identical).
+  // permanent → filled = acquired.
+  const filledCount = variant === "transient" ? Math.max(0, max - used) : used;
+  const hasTouchPad = d.touch.length > 0;
+
+  return (
+    <div
+      className={`flex flex-wrap ${d.gap}`}
+      role="group"
+      aria-label={ariaLabel}
+    >
+      {Array.from({ length: max }, (_, i) => {
+        const isFilled = i < filledCount;
+        const label = dotAriaLabel
+          ? dotAriaLabel(i, isFilled)
+          : `${ariaLabel} ${i + 1}/${max}`;
+        const cursor = readOnly
+          ? "cursor-default"
+          : hasTouchPad
+            ? "cursor-pointer"
+            : "cursor-pointer hover:opacity-80";
+        const bounceClass = bouncingDot === i ? d.bounceScale : "scale-100";
+        const dotSpan = (
+          <span
+            className={`${d.dot} rounded-full border transition-transform duration-200 ${
+              isFilled ? filledClassName : d.empty
+            } ${bounceClass}`}
+          />
+        );
+
+        return (
+          <button
+            key={i}
+            type="button"
+            role="checkbox"
+            aria-checked={isFilled}
+            aria-label={label}
+            onClick={() => handleToggle(i)}
+            disabled={readOnly}
+            className={
+              hasTouchPad
+                ? `${d.touch} ${cursor}`
+                : `${d.dot} rounded-full border transition-transform duration-200 ${
+                    isFilled ? filledClassName : d.empty
+                  } ${bouncingDot === i ? d.bounceScale : ""} ${cursor}`
+            }
+          >
+            {hasTouchPad ? dotSpan : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/ui/__tests__/SpellSlotGrid.test.tsx
+++ b/components/ui/__tests__/SpellSlotGrid.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment jsdom
+ *
+ * SpellSlotGrid unit tests — EP-0 C0.2.
+ *
+ * Ensures the consolidation primitive reproduces the exact behavior of the
+ * legacy ResourceDots + combat SpellSlotTracker implementations without
+ * flipping any visual semantic (the semantic flip is a Sprint 5 concern
+ * behind NEXT_PUBLIC_PLAYER_HQ_V2).
+ */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SpellSlotGrid } from "../SpellSlotGrid";
+
+describe("SpellSlotGrid", () => {
+  describe("rendering", () => {
+    it("renders exactly `max` checkboxes", () => {
+      render(
+        <SpellSlotGrid used={0} max={4} variant="transient" ariaLabel="Level 1" />
+      );
+      expect(screen.getAllByRole("checkbox")).toHaveLength(4);
+    });
+
+    it("wraps the whole row in a group with the supplied ariaLabel", () => {
+      render(
+        <SpellSlotGrid used={1} max={3} variant="transient" ariaLabel="Level 2" />
+      );
+      expect(screen.getByRole("group", { name: "Level 2" })).toBeInTheDocument();
+    });
+
+    it("generates a default per-dot label when dotAriaLabel is omitted", () => {
+      render(
+        <SpellSlotGrid used={0} max={2} variant="transient" ariaLabel="Slots" />
+      );
+      expect(screen.getByRole("checkbox", { name: "Slots 1/2" })).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "Slots 2/2" })).toBeInTheDocument();
+    });
+
+    it("routes each dot through the custom dotAriaLabel formatter when provided", () => {
+      render(
+        <SpellSlotGrid
+          used={1}
+          max={3}
+          variant="transient"
+          ariaLabel="Level 3"
+          dotAriaLabel={(i, filled) => `dot ${i} ${filled ? "ON" : "OFF"}`}
+        />
+      );
+      // variant=transient, used=1, max=3 → filled indices 0,1 (remaining=2)
+      expect(screen.getByRole("checkbox", { name: "dot 0 ON" })).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "dot 1 ON" })).toBeInTheDocument();
+      expect(screen.getByRole("checkbox", { name: "dot 2 OFF" })).toBeInTheDocument();
+    });
+  });
+
+  describe("variant=transient (legacy-identical behavior)", () => {
+    it("marks the first `max - used` dots as checked", () => {
+      render(
+        <SpellSlotGrid used={1} max={4} variant="transient" ariaLabel="Slots" />
+      );
+      const dots = screen.getAllByRole("checkbox");
+      // remaining = 3 → indices 0,1,2 filled, index 3 empty
+      expect(dots[0]).toHaveAttribute("aria-checked", "true");
+      expect(dots[1]).toHaveAttribute("aria-checked", "true");
+      expect(dots[2]).toHaveAttribute("aria-checked", "true");
+      expect(dots[3]).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("marks every dot as empty when used === max", () => {
+      render(
+        <SpellSlotGrid used={3} max={3} variant="transient" ariaLabel="Slots" />
+      );
+      const dots = screen.getAllByRole("checkbox");
+      for (const dot of dots) {
+        expect(dot).toHaveAttribute("aria-checked", "false");
+      }
+    });
+
+    it("marks every dot as filled when used === 0", () => {
+      render(
+        <SpellSlotGrid used={0} max={3} variant="transient" ariaLabel="Slots" />
+      );
+      const dots = screen.getAllByRole("checkbox");
+      for (const dot of dots) {
+        expect(dot).toHaveAttribute("aria-checked", "true");
+      }
+    });
+
+    it("clamps negative filledCount when used > max (defensive)", () => {
+      // Shouldn't happen in practice, but the primitive must not crash.
+      render(
+        <SpellSlotGrid used={99} max={2} variant="transient" ariaLabel="Slots" />
+      );
+      const dots = screen.getAllByRole("checkbox");
+      expect(dots[0]).toHaveAttribute("aria-checked", "false");
+      expect(dots[1]).toHaveAttribute("aria-checked", "false");
+    });
+  });
+
+  describe("variant=permanent", () => {
+    it("marks the first `used` dots as checked (acquired)", () => {
+      render(
+        <SpellSlotGrid used={2} max={4} variant="permanent" ariaLabel="Feats" />
+      );
+      const dots = screen.getAllByRole("checkbox");
+      // used = 2 acquired → indices 0,1 filled
+      expect(dots[0]).toHaveAttribute("aria-checked", "true");
+      expect(dots[1]).toHaveAttribute("aria-checked", "true");
+      expect(dots[2]).toHaveAttribute("aria-checked", "false");
+      expect(dots[3]).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("marks every dot as empty when used === 0", () => {
+      render(
+        <SpellSlotGrid used={0} max={3} variant="permanent" ariaLabel="Feats" />
+      );
+      const dots = screen.getAllByRole("checkbox");
+      for (const dot of dots) {
+        expect(dot).toHaveAttribute("aria-checked", "false");
+      }
+    });
+  });
+
+  describe("onToggle", () => {
+    it("fires onToggle with the clicked dot index", () => {
+      const onToggle = jest.fn();
+      render(
+        <SpellSlotGrid
+          used={0}
+          max={3}
+          variant="transient"
+          onToggle={onToggle}
+          ariaLabel="Slots"
+        />
+      );
+      fireEvent.click(screen.getAllByRole("checkbox")[1]);
+      expect(onToggle).toHaveBeenCalledWith(1);
+    });
+
+    it("does not fire onToggle when readOnly is true", () => {
+      const onToggle = jest.fn();
+      render(
+        <SpellSlotGrid
+          used={0}
+          max={2}
+          variant="transient"
+          readOnly
+          onToggle={onToggle}
+          ariaLabel="Slots"
+        />
+      );
+      fireEvent.click(screen.getAllByRole("checkbox")[0]);
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when onToggle is undefined", () => {
+      render(
+        <SpellSlotGrid used={0} max={2} variant="transient" ariaLabel="Slots" />
+      );
+      expect(() => fireEvent.click(screen.getAllByRole("checkbox")[0])).not.toThrow();
+    });
+  });
+
+  describe("density presets", () => {
+    it("comfortable density wraps dots in a 44×44 invisible touch target", () => {
+      const { container } = render(
+        <SpellSlotGrid
+          used={0}
+          max={1}
+          variant="transient"
+          density="comfortable"
+          ariaLabel="Slots"
+        />
+      );
+      const button = container.querySelector("button");
+      expect(button?.className).toContain("min-w-[44px]");
+      expect(button?.className).toContain("min-h-[44px]");
+    });
+
+    it("compact density renders without the 44×44 touch target", () => {
+      const { container } = render(
+        <SpellSlotGrid
+          used={0}
+          max={1}
+          variant="transient"
+          density="compact"
+          ariaLabel="Slots"
+        />
+      );
+      const button = container.querySelector("button");
+      expect(button?.className).not.toContain("min-w-[44px]");
+      expect(button?.className).not.toContain("min-h-[44px]");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Consolidation primitive extracted from two duplicated spell-slot dot grid implementations:

- `components/player-hq/SpellSlotsHq.tsx` (HQ, amber, via `ResourceDots`)
- `components/player/SpellSlotTracker.tsx` (combat, purple, inline dots)

Both call sites now delegate to `components/ui/SpellSlotGrid.tsx`. 100% behavior preserved — **no dot semantic flip**; that is still Sprint 5's concern behind `NEXT_PUBLIC_PLAYER_HQ_V2` (PRD decision #37).

## Design choices

- **`variant` prop** (`"permanent" | "transient"`): captures the semantic without flipping it. Today both callers use `"transient"`, so `filled dot = slot available` — matches legacy bit-for-bit.
- **`density` preset** (`"comfortable" | "compact"`): bundles the visual deltas (dot size, gap, touch-pad, bounce scale, empty style) so each caller keeps its exact look.
  - `comfortable` = HQ (14px dots, gap-0.5, 44×44 invisible touch target per WCAG 2.1 SC 2.5.5)
  - `compact` = combat tracker (12px dots, gap-1, no touch padding)
- **`filledClassName`**: palette token passed by caller (amber for HQ, purple for combat).
- **`dotAriaLabel` hook**: preserves the combat tracker's richer per-dot aria labels.

## Test plan

- [x] Jest: 15/15 pass (`components/ui/__tests__/SpellSlotGrid.test.tsx`)
- [x] `tsc --noEmit` clean
- [x] ESLint: no net regression vs baseline (pre-existing issues only; one rules-of-hooks error in `SpellSlotTracker` actually resolved)
- [ ] Manual smoke: HQ spell slots click then used count updates; combat spell slot tracker click then broadcasts still fire
- [ ] Playwright regression on spell-slot specs (to be run by Dani/CI)

## Doc references

- `_bmad-output/party-mode-2026-04-22/12-reuse-matrix.md` §7.2 (consolidation)
- `_bmad-output/party-mode-2026-04-22/14-sprint-plan.md` Sprint 1 Track A row 3

Closes EP-0 C0.2.

Generated with [Claude Code](https://claude.com/claude-code)