### PR TITLE
feat(grimório): add CI Combat Parity gate (EP-INFRA.3)

### DIFF
--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -1,0 +1,67 @@
+name: Combat Parity Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [master]
+
+# Combat Parity Rule (see CLAUDE.md + docs/parity-check.md):
+# Any PR that touches combat/player/guest runtime components MUST ship
+# test coverage for the 3 access modes (Guest / Anon / Auth) OR declare
+# the parity intent explicitly in the PR description.
+#
+# This gate runs in parallel to the E2E suite — it doesn't run Playwright,
+# it only enforces the rule by diffing the PR. Result: near-instant check
+# (~15s) that blocks merge when the rule is violated.
+
+jobs:
+  parity-check:
+    name: Combat Parity Gate
+    runs-on: ubuntu-latest
+    # Skip for draft PRs — author is still iterating.
+    if: github.event.pull_request.draft == false
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout PR head + base
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compute changed files (base..head)
+        id: diff
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          git fetch --no-tags --depth=50 origin "$BASE" >/dev/null 2>&1 || true
+          CHANGED=$(git diff --name-only "$BASE" "$HEAD")
+          echo "Changed files between $BASE..$HEAD:"
+          echo "$CHANGED"
+          {
+            echo 'files<<__EOF__'
+            echo "$CHANGED"
+            echo '__EOF__'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run parity gate
+        id: gate
+        env:
+          CHANGED_FILES: ${{ steps.diff.outputs.files }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/parity-check.mjs
+
+      - name: Post status summary
+        if: always()
+        run: |
+          {
+            echo "## Combat Parity Gate"
+            echo ""
+            echo "See \`docs/parity-check.md\` for rules. To bypass in rare cases where"
+            echo "parity genuinely does not apply (e.g. type-only refactor), add the label"
+            echo "\`parity-exempt\` to the PR and explain in the description."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/parity-check.md
+++ b/docs/parity-check.md
@@ -14,7 +14,7 @@ Guest (`/try`), Anonymous (`/join`), and Authenticated (`/invite` + login).
 The gate:
 
 1. Diffs the PR against its base.
-2. Flags files under `components/combat/`, `components/player/`, `components/guest/`, or the corresponding `app/**` routes (`/try`, `/join`, `/invite`, `/app/combat`, `/app/campaigns/*/sheet|journey|run`).
+2. Flags files under `components/combat/`, `components/player/`, `components/guest/`, or the corresponding `app/**` routes (`/try`, `/join`, `/app/combat`, `/app/campaigns/*/sheet|journey|run`). Route-group segments like `(with-sidebar)` and `(focused)` are transparent to the matcher — a path like `app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx` triggers the gate.
 3. For each added/changed `e2e/**.spec.ts` in the same PR, scans for mode-specific signals:
    - **Guest** — `/try`, `GuestCombatClient`, `guest-try-mode` references
    - **Anon** — `/join/`, `signInAnonymously`, `session_tokens` references
@@ -40,7 +40,7 @@ hatches in order of preference:
 
 ### 1. Declare parity-intent in the PR body
 
-Best for features that genuinely are Auth-only (data persistence, DM-only
+Best for features that genuinely are Auth-only (data persistence, Mestre-only
 features, realtime that Guest can't do). Add a block anywhere in the PR
 description:
 
@@ -52,8 +52,10 @@ anon: n/a (requires campaign_members)
 ```
 
 The gate parses the block and accepts `n/a`, `na`, `skip`, or `exempt` as
-the value. The Auth mode cannot be declared n/a — every combat-touching
-change must have at least one Auth-mode spec covering it.
+the value **for `guest` and `anon` only**. Attempting `auth: n/a` makes the
+gate fail with an explicit error — every combat-touching change must have
+at least one Auth-mode spec covering it, full stop. If the feature truly
+does not apply to any authenticated user, it probably shouldn't ship.
 
 ### 2. Use the `parity-exempt` PR label
 

--- a/docs/parity-check.md
+++ b/docs/parity-check.md
@@ -1,0 +1,140 @@
+# Combat Parity CI Gate
+
+**Workflow:** [`.github/workflows/parity-check.yml`](../.github/workflows/parity-check.yml)
+**Script:** [`scripts/ci/parity-check.mjs`](../scripts/ci/parity-check.mjs)
+**Rule:** [Combat Parity Rule in CLAUDE.md](../CLAUDE.md#combat-parity-rule--guest-vs-auth)
+
+## What it does
+
+Every PR against `master` runs a lightweight gate (~15s, no Playwright)
+that enforces the Combat Parity Rule: **if you change combat/player/guest
+runtime code, you must ship test coverage for all 3 access modes** —
+Guest (`/try`), Anonymous (`/join`), and Authenticated (`/invite` + login).
+
+The gate:
+
+1. Diffs the PR against its base.
+2. Flags files under `components/combat/`, `components/player/`, `components/guest/`, or the corresponding `app/**` routes (`/try`, `/join`, `/invite`, `/app/combat`, `/app/campaigns/*/sheet|journey|run`).
+3. For each added/changed `e2e/**.spec.ts` in the same PR, scans for mode-specific signals:
+   - **Guest** — `/try`, `GuestCombatClient`, `guest-try-mode` references
+   - **Anon** — `/join/`, `signInAnonymously`, `session_tokens` references
+   - **Auth** — `loginAs`/`loginAsDM`, `/invite/`, `E2E_DM_EMAIL`, `campaign_members` references
+4. **Passes** only when every mode has at least one spec with evidence — OR the PR author declares the mode is N/A (see below).
+5. Never runs for draft PRs.
+
+## Mode → client reference
+
+Reproduced from CLAUDE.md for convenience:
+
+| Mode | Client Principal | Store/Auth | Entry Point |
+|------|-----------------|------------|-------------|
+| Guest | `components/guest/GuestCombatClient.tsx` | Zustand + localStorage | `/app/try/page.tsx` |
+| Anônimo | `components/player/PlayerJoinClient.tsx` | Supabase anon auth + session_tokens | `/app/join/[token]/page.tsx` |
+| Autenticado | `components/player/PlayerJoinClient.tsx` | Supabase auth + campaign_members | `/app/invite/[token]/page.tsx` |
+
+## When the gate is wrong
+
+The heuristic is intentionally conservative — false positives are cheap
+to clear, false negatives let parity drift and break prod. Three escape
+hatches in order of preference:
+
+### 1. Declare parity-intent in the PR body
+
+Best for features that genuinely are Auth-only (data persistence, DM-only
+features, realtime that Guest can't do). Add a block anywhere in the PR
+description:
+
+```markdown
+<!-- parity-intent
+guest: n/a (data persistence, Auth-only)
+anon: n/a (requires campaign_members)
+-->
+```
+
+The gate parses the block and accepts `n/a`, `na`, `skip`, or `exempt` as
+the value. The Auth mode cannot be declared n/a — every combat-touching
+change must have at least one Auth-mode spec covering it.
+
+### 2. Use the `parity-exempt` PR label
+
+For pure refactors with no behavior change (type renames, comment sweeps,
+import reordering, extracting a helper without call-site changes). The gate
+logs the exempted files but passes. The PR description should still explain
+WHY parity does not apply.
+
+### 3. Add the missing spec
+
+The canonical fix. Add or extend an `e2e/**.spec.ts` that exercises the
+missing mode. Reference the table above for entry points and the
+[`e2e/helpers/auth.ts`](../e2e/helpers/auth.ts) helpers:
+
+```ts
+// Auth mode
+await loginAs(page, PLAYER_WARRIOR);
+
+// Anon mode
+await joinSession(page, shareToken);  // drives /join/[token]
+
+// Guest mode
+await page.goto("/try");
+```
+
+## What the gate does NOT do
+
+- **Does not run Playwright** — the actual tests run in the existing [E2E Tests](../.github/workflows/e2e.yml) workflow. This gate only enforces coverage breadth, not correctness.
+- **Does not validate spec quality** — a spec that imports `/try` but doesn't actually exercise combat flow still passes the heuristic. The reviewer owns that judgment call.
+- **Does not check unit tests** — unit tests in `tests/` or `lib/**/*.test.ts` don't count toward parity.
+- **Does not run on pushes to `master`** — the gate is PR-only. Merges to master are already downstream of the gate.
+- **Does not run on draft PRs** — gives authors room to iterate before the red X appears.
+
+## Failure output
+
+When the gate fails, the job logs include:
+
+```
+❌ Combat Parity Gate FAILED.
+
+This PR changes combat/player/guest runtime but does not ship spec
+evidence for: GUEST, ANON
+
+To resolve, do ONE of the following:
+  1. Add/edit e2e/**.spec.ts files that exercise the missing mode(s).
+  2. Add a parity-intent block to the PR body (...)
+  3. Add the label `parity-exempt` if this is a pure refactor.
+```
+
+Fix by pushing another commit to the same branch (gate re-runs on
+`synchronize`) or by editing the PR body / adding a label and retrying
+via the Re-run jobs button.
+
+## Development — testing the gate locally
+
+Simulate a PR by setting the env vars manually:
+
+```bash
+cd /path/to/repo
+CHANGED_FILES="components/combat/CombatantRow.tsx" \
+PR_BODY="" \
+PR_LABELS="[]" \
+node scripts/ci/parity-check.mjs
+# → exits 1 (no spec evidence)
+
+CHANGED_FILES="components/combat/CombatantRow.tsx
+e2e/combat/player-view.spec.ts" \
+PR_BODY="" \
+PR_LABELS="[]" \
+node scripts/ci/parity-check.mjs
+# → exits 1 if the spec doesn't cover all modes
+```
+
+The script auto-exits 0 when CHANGED_FILES contains only docs, tests, or
+non-triggering paths.
+
+## Roadmap
+
+- Add a matrix-expansion check: "if you added a new Playwright spec, does
+  the corresponding Playwright project list both desktop-chrome + mobile?"
+  Out of scope for Sprint 1 — will revisit when mobile parity becomes a
+  sprint focus.
+- Integrate with CODEOWNERS to auto-ping the combat parity expert on gate
+  failures. Deferred pending team expansion.

--- a/scripts/ci/parity-check.mjs
+++ b/scripts/ci/parity-check.mjs
@@ -43,7 +43,22 @@ try {
   labels = [];
 }
 
-/** Triggering paths — changes here invoke the parity rule. */
+/** Triggering paths — changes here invoke the parity rule.
+ *
+ * Next.js route groups: segments wrapped in `(...)` don't appear in the URL
+ * but ARE part of the filesystem path. Real paths look like
+ *   app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx
+ *   app/app/(focused)/combat/[id]/page.tsx
+ * so the triggers below optionally consume a `(...)` segment after
+ * `app/app/` (and after `app/` for the top-level combat mirror) to avoid
+ * silently skipping 90% of combat-touching PRs.
+ *
+ * Note: there is no `app/invite/` route in this codebase — the Authenticated
+ * entry point is the same PlayerJoinClient mounted via `/join/[token]` with
+ * a logged-in user (see CLAUDE.md Combat Parity Rule). `invite` stays in the
+ * SIGNALS map as a spec-side hint only.
+ */
+const ROUTE_GROUP = "(?:\\([^)]+\\)/)?"; // optionally consume a (group)/ segment
 const TRIGGER_GLOBS = [
   (f) => f.startsWith("components/combat/"),
   (f) => f.startsWith("components/player/"),
@@ -51,9 +66,11 @@ const TRIGGER_GLOBS = [
   // App routes that host those components
   (f) => f.startsWith("app/try/"),
   (f) => f.startsWith("app/join/"),
-  (f) => f.startsWith("app/invite/"),
-  (f) => f.startsWith("app/app/campaigns/") && /combat|sheet|journey|run/.test(f),
-  (f) => f.startsWith("app/combat/"),
+  // Campaign HQ modes (sheet/run/journey) under whatever route group.
+  (f) => new RegExp(`^app/app/${ROUTE_GROUP}campaigns/.*/(sheet|run|journey)(/|$)`).test(f),
+  // Dedicated combat screen under whatever route group.
+  (f) => new RegExp(`^app/app/${ROUTE_GROUP}combat/`).test(f),
+  (f) => new RegExp(`^app/${ROUTE_GROUP}combat/`).test(f),
 ];
 
 /** Test-only paths — don't count as "touching combat" even if they match triggers. */
@@ -179,12 +196,35 @@ if (missing.length === 0) {
  */
 const intentMatch = /<!--\s*parity-intent([\s\S]*?)-->/i.exec(PR_BODY);
 const declaredNA = new Set();
+let authNAAttempted = false;
 if (intentMatch) {
   const block = intentMatch[1];
   for (const line of block.split(/\r?\n/)) {
     const m = /^\s*(guest|anon|auth)\s*:\s*(n\/a|na|skip|exempt)\b/i.exec(line);
-    if (m) declaredNA.add(m[1].toLowerCase());
+    if (!m) continue;
+    const mode = m[1].toLowerCase();
+    // Auth mode is NEVER allowed to be declared n/a. Every combat-touching
+    // change must have at least one Auth-mode spec (see docs/parity-check.md).
+    // Silently dropping this was the most severe bypass in the gate.
+    if (mode === "auth") {
+      authNAAttempted = true;
+      continue;
+    }
+    declaredNA.add(mode);
   }
+}
+
+if (authNAAttempted) {
+  console.log("❌ Combat Parity Gate FAILED.");
+  console.log("");
+  console.log("PR body declares `auth: n/a` in its parity-intent block, but auth");
+  console.log("mode cannot be declared n/a — every combat-touching change must");
+  console.log("have at least one Auth-mode spec.");
+  console.log("");
+  console.log("Remove the `auth: ...` line from the parity-intent block and add a");
+  console.log("spec under e2e/ that exercises the Authenticated path (loginAs +");
+  console.log("the relevant flow). See docs/parity-check.md §'When the gate is wrong'.");
+  process.exit(1);
 }
 
 if (declaredNA.size > 0) {

--- a/scripts/ci/parity-check.mjs
+++ b/scripts/ci/parity-check.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Combat Parity Gate — enforces the Combat Parity Rule from CLAUDE.md.
+ *
+ * Rule (paraphrased):
+ *   Any PR that changes combat/player/guest runtime components MUST ship
+ *   test coverage for the 3 access modes (Guest / Anon / Auth) OR declare
+ *   that parity does not apply (label `parity-exempt` + rationale in PR body).
+ *
+ * How this script decides:
+ *   1. Read CHANGED_FILES (multi-line string, one file per line) from env.
+ *   2. If NONE of the changed files match a "triggering path" → PASS (rule
+ *      not invoked at all).
+ *   3. If triggering paths exist, check for "covering" evidence:
+ *        a) The PR adds/edits at least one spec under e2e/ that clearly
+ *           exercises each of the 3 modes (Guest OR /try, Anon OR /join,
+ *           Auth OR /invite + loginAs), AND
+ *        b) UI-only changes still require at least one spec touching Auth
+ *           path (Guest + Anon optional if doc-labelled as auth-only).
+ *      The heuristic is intentionally conservative — false positives are
+ *      cheap to clear (add `parity-exempt` label + explain), false
+ *      negatives let parity drift.
+ *   4. If PR has label `parity-exempt` → PASS with warning only.
+ *
+ * The heuristic is imperfect by design. See `docs/parity-check.md` §"When
+ * the gate is wrong" for how to override.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const CHANGED = (process.env.CHANGED_FILES ?? "")
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const PR_BODY = process.env.PR_BODY ?? "";
+const PR_LABELS_RAW = process.env.PR_LABELS ?? "[]";
+let labels = [];
+try {
+  labels = JSON.parse(PR_LABELS_RAW);
+} catch {
+  labels = [];
+}
+
+/** Triggering paths — changes here invoke the parity rule. */
+const TRIGGER_GLOBS = [
+  (f) => f.startsWith("components/combat/"),
+  (f) => f.startsWith("components/player/"),
+  (f) => f.startsWith("components/guest/"),
+  // App routes that host those components
+  (f) => f.startsWith("app/try/"),
+  (f) => f.startsWith("app/join/"),
+  (f) => f.startsWith("app/invite/"),
+  (f) => f.startsWith("app/app/campaigns/") && /combat|sheet|journey|run/.test(f),
+  (f) => f.startsWith("app/combat/"),
+];
+
+/** Test-only paths — don't count as "touching combat" even if they match triggers. */
+const IS_TEST_FILE = (f) =>
+  f.startsWith("e2e/") ||
+  f.startsWith("tests/") ||
+  f.endsWith(".test.ts") ||
+  f.endsWith(".test.tsx") ||
+  f.endsWith(".spec.ts") ||
+  f.endsWith(".spec.tsx");
+
+/** Files that definitely don't count as "runtime" — docs, generated, etc. */
+const NON_RUNTIME = (f) =>
+  f.endsWith(".md") ||
+  f.startsWith("docs/") ||
+  f.startsWith("_bmad-output/") ||
+  f.startsWith("_bmad/") ||
+  f.startsWith(".claude/");
+
+/** Classify each changed file. */
+const triggering = CHANGED.filter((f) => {
+  if (IS_TEST_FILE(f)) return false;
+  if (NON_RUNTIME(f)) return false;
+  return TRIGGER_GLOBS.some((fn) => fn(f));
+});
+
+const specChanges = CHANGED.filter((f) => f.startsWith("e2e/") && (f.endsWith(".spec.ts") || f.endsWith(".spec.tsx")));
+
+/** Label exemption — bypass entirely. */
+if (labels.includes("parity-exempt")) {
+  console.log("✅ Parity gate bypassed via `parity-exempt` label.");
+  console.log("   Triggering files:");
+  for (const f of triggering) console.log("     -", f);
+  console.log("\n   Ensure the PR description explains WHY parity does not apply.");
+  process.exit(0);
+}
+
+/** Short-circuit: no triggering files. */
+if (triggering.length === 0) {
+  console.log("✅ No combat/player/guest runtime files changed — parity gate not invoked.");
+  process.exit(0);
+}
+
+console.log("Combat Parity Gate invoked — PR touches runtime combat/player/guest files:");
+for (const f of triggering) console.log("  -", f);
+console.log("");
+
+/**
+ * Evidence heuristic: scan every added/changed spec file for signals of
+ * each mode. A spec that only references one mode counts only for that
+ * mode; a spec touching multiple modes counts for each.
+ */
+const SIGNALS = {
+  guest: [/\/try\b/, /GuestCombatClient/, /guest-try-mode/, /\bguest\b/i],
+  anon: [
+    /\/join\//,
+    /signInAnonymously/,
+    // `session_token` (singular or plural) — RLS column name referenced
+    // by anon-aware specs. Broader than token literals but tight enough
+    // that it doesn't match unrelated tokens like `session_id`.
+    /\bsession_tokens?\b/,
+    // Literal "Anon" / "Anonymous" only in spec-title-ish contexts:
+    // a capitalized word at start of a line or inside common assertion
+    // messages. Avoids the `supabase-anon-key` false positive.
+    /\bAnonymous\b/,
+    /\b[Aa]non\s+(?:user|player|mode|session|join|browser|context|tab)\b/,
+    // Helpers that drive the anon-via-/join flow — player joins without
+    // a prior auth step. `joinSession` and `playerJoinCombat` both route
+    // through PlayerJoinClient + session_tokens.
+    /\bjoinSession\b/,
+    /\bplayerJoinCombat\b/,
+    /\bjoinAsPlayer\b/,
+  ],
+  auth: [/loginAs(?:DM)?\b/, /\/invite\//, /E2E_DM_EMAIL/, /campaign_members/, /\bauthenticated\b/i],
+};
+
+const modesCovered = { guest: [], anon: [], auth: [] };
+
+for (const spec of specChanges) {
+  let content = "";
+  try {
+    content = readFileSync(path.resolve(spec), "utf8");
+  } catch {
+    // File was deleted; skip.
+    continue;
+  }
+  for (const [mode, patterns] of Object.entries(SIGNALS)) {
+    if (patterns.some((re) => re.test(content))) {
+      modesCovered[mode].push(spec);
+    }
+  }
+}
+
+console.log("Spec evidence (changed/added under e2e/):");
+for (const [mode, files] of Object.entries(modesCovered)) {
+  const label = mode.toUpperCase().padEnd(5);
+  if (files.length === 0) {
+    console.log(`  ${label} — ❌ no covering spec change`);
+  } else {
+    console.log(`  ${label} — ✅ ${files.length} spec(s):`);
+    for (const f of files) console.log("          ", f);
+  }
+}
+console.log("");
+
+const missing = Object.entries(modesCovered)
+  .filter(([, files]) => files.length === 0)
+  .map(([mode]) => mode);
+
+if (missing.length === 0) {
+  console.log("✅ All 3 modes have spec evidence in this PR.");
+  process.exit(0);
+}
+
+/**
+ * Missing modes — but allow PR author to declare mode-specific intent in
+ * the body. Look for block:
+ *
+ *   <!-- parity-intent
+ *   guest: n/a (data persistence feature, Auth-only)
+ *   anon: n/a (data persistence feature, Auth-only)
+ *   -->
+ */
+const intentMatch = /<!--\s*parity-intent([\s\S]*?)-->/i.exec(PR_BODY);
+const declaredNA = new Set();
+if (intentMatch) {
+  const block = intentMatch[1];
+  for (const line of block.split(/\r?\n/)) {
+    const m = /^\s*(guest|anon|auth)\s*:\s*(n\/a|na|skip|exempt)\b/i.exec(line);
+    if (m) declaredNA.add(m[1].toLowerCase());
+  }
+}
+
+if (declaredNA.size > 0) {
+  console.log("PR declares parity-intent in body:");
+  for (const mode of declaredNA) console.log(`  ${mode.toUpperCase()} → N/A`);
+  console.log("");
+}
+
+const stillMissing = missing.filter((m) => !declaredNA.has(m));
+if (stillMissing.length === 0) {
+  console.log("✅ Remaining modes covered by parity-intent declarations.");
+  process.exit(0);
+}
+
+console.log("❌ Combat Parity Gate FAILED.");
+console.log("");
+console.log("This PR changes combat/player/guest runtime but does not ship spec");
+console.log(`evidence for: ${stillMissing.map((m) => m.toUpperCase()).join(", ")}`);
+console.log("");
+console.log("To resolve, do ONE of the following:");
+console.log("  1. Add/edit e2e/**.spec.ts files that exercise the missing mode(s).");
+console.log("     See the mode → client table in CLAUDE.md (Combat Parity Rule).");
+console.log("  2. Add a parity-intent block to the PR body for modes where the");
+console.log("     feature genuinely does not apply, e.g.:");
+console.log("");
+console.log("       <!-- parity-intent");
+console.log("       guest: n/a (data persistence, Auth-only)");
+console.log("       -->");
+console.log("");
+console.log("  3. If this PR is a pure refactor with no behavior change, add the");
+console.log("     label `parity-exempt` and explain in the PR body.");
+console.log("");
+console.log("See docs/parity-check.md for full guidance.");
+process.exit(1);


### PR DESCRIPTION
## Summary

Sprint 1 Track B — enforces the [Combat Parity Rule](../blob/master/CLAUDE.md#combat-parity-rule--guest-vs-auth) automatically on every PR against master.

The gate is PR-only and runs in parallel to the full E2E suite. It does not run Playwright — instead it diffs the PR and asserts that when combat/player/guest runtime code changes, the PR also ships spec evidence for the 3 access modes (Guest / Anon / Auth).

## What's in this PR

- **`.github/workflows/parity-check.yml`** — new workflow, runs on `pull_request` (opened/synchronize/reopened/ready_for_review). Skips drafts. ~15s wall time.
- **`scripts/ci/parity-check.mjs`** — heuristic diff scanner:
  - Classifies changed files into "triggering" (runtime combat/player/guest + corresponding app routes) vs. ignorable (docs, tests, `_bmad-output/`, etc.)
  - Scans added/edited `e2e/**.spec.ts` for per-mode signals (regex patterns referencing each mode's entry points + helpers)
  - Three escape hatches:
    1. `<!-- parity-intent -->` block in PR body marks modes as `n/a` / `skip` / `exempt` (Auth cannot be declared n/a)
    2. `parity-exempt` label bypasses the gate entirely (for pure refactors with no behavior change)
    3. Add the missing spec (canonical fix)
- **`docs/parity-check.md`** — documentation: rules, mode → client table (mirrored from CLAUDE.md), failure-output walkthrough, local-dev testing snippet, roadmap notes.

## Local testing (all 5 scenarios pass)

```bash
# 1. docs-only → PASS (gate not invoked)
CHANGED_FILES=\"docs/foo.md\" node scripts/ci/parity-check.mjs  # exit 0

# 2. combat change + no specs → FAIL
CHANGED_FILES=\"components/combat/CombatantRow.tsx\" node scripts/ci/parity-check.mjs  # exit 1

# 3. combat change + 3-mode specs → PASS
CHANGED_FILES=\"components/combat/CombatantRow.tsx
e2e/combat/player-view.spec.ts
e2e/journeys/guest-try-mode.spec.ts\" node scripts/ci/parity-check.mjs  # exit 0

# 4. auth-only feature via parity-intent → PASS
CHANGED_FILES=\"components/player/PlayerJoinClient.tsx
e2e/features/active-effects.spec.ts\" \
PR_BODY=\"<!-- parity-intent
guest: n/a
anon: n/a
-->\" node scripts/ci/parity-check.mjs  # exit 0

# 5. parity-exempt label → PASS with warning
CHANGED_FILES=\"components/combat/CombatantRow.tsx\" \
PR_LABELS='[\"parity-exempt\"]' node scripts/ci/parity-check.mjs  # exit 0
```

Regex tightening during development: initial version false-positive on `supabase-anon-key` (in active-effects.spec.ts). Fixed by replacing `/\banon\b/i` with `/\bAnonymous\b/` + `/\b[Aa]non\s+(?:user|player|mode|session|...)\b/` patterns.

## What the gate does NOT do

- Does not run Playwright (the E2E workflow does that separately)
- Does not validate spec quality (a spec that imports `/try` without exercising combat still passes — reviewer judgment required)
- Does not count unit tests in `tests/` or `lib/**/*.test.ts` toward parity
- Does not run on pushes to master (PR-only)
- Does not run on draft PRs (gives authors room to iterate)

## Verifying the gate blocks a bad PR

Once this PR merges, the plan is to verify the gate blocks a deliberately-bad PR (e.g. a test PR that modifies `components/combat/CombatantRow.tsx` without adding any spec). The gate's \"exit 1\" path was verified locally above; CI parity with local behavior is straightforward because the script reads plain env vars and does not depend on Playwright infra.

> Note: this PR itself is a **pure infra change** (only adds workflow + script + docs, no runtime file edits) so the gate doesn't self-invoke. On merge, subsequent PRs that touch combat/player/guest will be the first real invocations.

## Test plan

- [x] Script syntax: `node scripts/ci/parity-check.mjs` runs clean with env var inputs
- [x] All 5 local scenarios produce expected exit codes
- [x] Regex against real existing specs: `player-view.spec.ts` detected as Anon+Auth; `guest-try-mode.spec.ts` as Guest; `active-effects.spec.ts` as Auth only (not false-positive anon)
- [x] Workflow YAML parses (GitHub will validate on push)
- [x] `rtk tsc --noEmit` — clean (no TS files added)
- [ ] Dani: after merge, open a test PR deliberately failing the gate to confirm CI blocks it (or just let the first real combat PR validate in the wild)

## References

- [CLAUDE.md — Combat Parity Rule](../blob/master/CLAUDE.md#combat-parity-rule--guest-vs-auth)
- [`_bmad-output/party-mode-2026-04-22/15-e2e-matrix.md`](../blob/master/_bmad-output/party-mode-2026-04-22/15-e2e-matrix.md) §\"Wave merge gates\" — informs which spec paths are considered mode-covering
- [`_bmad-output/party-mode-2026-04-22/14-sprint-plan.md`](../blob/master/_bmad-output/party-mode-2026-04-22/14-sprint-plan.md) Sprint 1 Track B item 3

Closes EP-INFRA.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)