### PR TITLE
feat(grimório): add /sheet E2E baseline scaffolding (EP-INFRA.4)

### DIFF
--- a/e2e/player-hq/README.md
+++ b/e2e/player-hq/README.md
@@ -1,0 +1,50 @@
+# Player HQ E2E — Baseline
+
+Sprint 1 Track B (EP-INFRA.4) scaffold. Lives side-by-side with the
+existing `e2e/features/active-effects*.spec.ts` Player HQ coverage but
+targets the **shell topology** instead of feature-level lifecycle.
+
+## What's here
+
+| Spec | Mode | Target |
+|---|---|---|
+| `sheet-smoke.spec.ts` | Auth | Pre-refactor baseline: 7-tab shell renders on `/app/campaigns/[id]/sheet` |
+| `sheet-smoke-anon.spec.ts` | Anon (via `/join/[token]`) | Anon player cannot reach `/sheet` (documents the redirect) |
+| `sheet-smoke-guest.spec.ts` | Guest (via `/try`) | Guest does not have `/sheet` equivalent (documents the gap) |
+
+All three are **baseline** — they capture the current V1 behavior so
+Sprint 2+ can catch regressions when the V2 shell arrives behind
+`NEXT_PUBLIC_PLAYER_HQ_V2`.
+
+## Running locally
+
+```bash
+# Full player-hq folder
+rtk playwright test e2e/player-hq/
+
+# Single spec
+rtk playwright test e2e/player-hq/sheet-smoke.spec.ts --project=desktop-chrome
+
+# Headed for debugging
+rtk playwright test e2e/player-hq/sheet-smoke.spec.ts --headed
+```
+
+## What these specs deliberately do NOT assert
+
+- **Tab switching interaction** — reserved for Sprint 2+ when B5 deep-links
+  + B4 persistence land. Today the tabs are purely client-state so a
+  pre-refactor test would be fragile.
+- **Content correctness inside each tab** — `e2e/features/active-effects.spec.ts`
+  owns that for Resources; `e2e/journeys/j21-player-ui-panels.spec.ts`
+  owns spell slots; etc.
+- **Feature-flag gating** — the V2 flag has zero call sites as of Sprint 1;
+  assertions tied to it will appear in Sprint 2+ once `isPlayerHqV2Enabled()`
+  is consumed.
+
+## Why 3 specs for parity
+
+The Combat Parity CI gate (`docs/parity-check.md`) requires spec evidence
+for all 3 modes whenever combat/player runtime changes. The Anon and Guest
+specs document **why** those modes do NOT have a `/sheet` equivalent so
+that future refactors make that intentional gap explicit rather than
+accidentally introducing broken redirects.

--- a/e2e/player-hq/README.md
+++ b/e2e/player-hq/README.md
@@ -43,8 +43,9 @@ rtk playwright test e2e/player-hq/sheet-smoke.spec.ts --headed
 
 ## Why 3 specs for parity
 
-The Combat Parity CI gate (`docs/parity-check.md`) requires spec evidence
-for all 3 modes whenever combat/player runtime changes. The Anon and Guest
-specs document **why** those modes do NOT have a `/sheet` equivalent so
-that future refactors make that intentional gap explicit rather than
+The Combat Parity Rule (see `CLAUDE.md` § *Combat Parity Rule — Guest vs
+Auth*) requires spec evidence for all 3 modes (Guest / Anon / Auth)
+whenever combat or player runtime changes. The Anon and Guest specs
+document **why** those modes do NOT have a `/sheet` equivalent so that
+future refactors make that intentional gap explicit rather than
 accidentally introducing broken redirects.

--- a/e2e/player-hq/_constants.ts
+++ b/e2e/player-hq/_constants.ts
@@ -1,0 +1,29 @@
+/**
+ * Player HQ — Shared E2E constants (EP-INFRA.4, Sprint 1 Track B).
+ *
+ * Filename starts with `_` so Playwright's default test matcher
+ * (`**\/*.spec.ts` / `**\/*.test.ts`) does NOT pick it up as a spec.
+ *
+ * Keep this file tiny on purpose: spec-scoped constants only. Broader
+ * helpers belong in `e2e/helpers/`.
+ */
+
+/**
+ * V1 tab keys rendered by `components/player-hq/PlayerHqShell.tsx`.
+ *
+ * Order matches the visual order in the shell's tablist; if Sprint 2
+ * introduces the 4-tab V2 shell (Herói / Arsenal / Diário / Mapa) behind
+ * `NEXT_PUBLIC_PLAYER_HQ_V2`, add a sibling `TAB_KEYS_V2` — do NOT mutate
+ * this list (baseline specs depend on the exact V1 ordering).
+ */
+export const TAB_KEYS = [
+  "map",
+  "sheet",
+  "resources",
+  "abilities",
+  "inventory",
+  "notes",
+  "quests",
+] as const;
+
+export type PlayerHqTabKey = (typeof TAB_KEYS)[number];

--- a/e2e/player-hq/sheet-smoke-anon.spec.ts
+++ b/e2e/player-hq/sheet-smoke-anon.spec.ts
@@ -44,8 +44,12 @@ test.describe("Player HQ — Anon smoke (no /sheet access baseline)", () => {
     await page.waitForLoadState("domcontentloaded");
 
     // Expect redirect to login, NOT a rendered sheet.
+    // Source of truth: app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx:21
+    // → `if (!user) redirect("/auth/login")`. Match path exactly (with or
+    // without query string), not a permissive fallback that would accept
+    // the root `/` and mask future regressions.
     expect(page.url()).not.toMatch(/\/sheet(?:\?|$)/);
-    expect(page.url()).toMatch(/\/auth\/login|\/join\/|\/try|\/$/);
+    expect(page.url()).toMatch(/\/auth\/login(?:\?|$)/);
 
     // The tablist must NOT exist for anon visitors.
     const tablist = page.locator('[role="tablist"]');

--- a/e2e/player-hq/sheet-smoke-anon.spec.ts
+++ b/e2e/player-hq/sheet-smoke-anon.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Player HQ — Anon smoke baseline (EP-INFRA.4, Sprint 1 Track B).
+ *
+ * Documents the intentional gap: anonymous players (entered via `/join/
+ * [token]`) do NOT have access to `/app/campaigns/[id]/sheet`. The sheet
+ * page's server component at `app/app/(with-sidebar)/campaigns/[id]/
+ * sheet/page.tsx` redirects when `user` is null or when `membership.role`
+ * is not `player`.
+ *
+ * Capturing this baseline matters because Sprint 2+ will start reshuffling
+ * redirects (e.g. decision #43 — post-combat redirect changes destination
+ * by role and flag). If a future refactor accidentally lets anon users
+ * reach `/sheet` (or lets them land on a broken shell), this spec fails
+ * with a clear pointer to the regression.
+ *
+ * Why an anon-focused baseline is valuable even though anon does not
+ * currently reach the shell:
+ *   1. Track B Sprint 2 rewrites conversion specs (recap-anon-signup +
+ *      recap-guest-signup-migrate) to expect a new dual redirect target.
+ *   2. Sprint 3+ may add a pared-down "anon sheet" for limited features
+ *      (Arsenal read-only, etc.) — the baseline becomes the checkpoint
+ *      where we decide "yes that change is intentional."
+ *
+ * Skip behavior: this test never exercises a real share token — it drives
+ * anon access by visiting `/sheet` directly without authentication. No
+ * seed data dependency.
+ */
+
+test.describe("Player HQ — Anon smoke (no /sheet access baseline)", () => {
+  test.setTimeout(45_000);
+
+  test("unauthenticated visit to /sheet redirects to /auth/login", async ({ page }) => {
+    // Use a plausible-looking UUID — even if the campaign existed, the
+    // redirect happens BEFORE the campaign lookup in the server component
+    // (`if (!user) redirect("/auth/login")`).
+    const fakeCampaignId = "00000000-0000-0000-0000-000000000000";
+
+    await page.goto(`/app/campaigns/${fakeCampaignId}/sheet`, {
+      timeout: 30_000,
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForLoadState("domcontentloaded");
+
+    // Expect redirect to login, NOT a rendered sheet.
+    expect(page.url()).not.toMatch(/\/sheet(?:\?|$)/);
+    expect(page.url()).toMatch(/\/auth\/login|\/join\/|\/try|\/$/);
+
+    // The tablist must NOT exist for anon visitors.
+    const tablist = page.locator('[role="tablist"]');
+    await expect(tablist).toHaveCount(0);
+  });
+
+  test("anon visitor landing on /join/[invalid-token] does not gain /sheet access", async ({
+    page,
+  }) => {
+    // Exercise the /join entry point with a bogus token to confirm the
+    // anon flow stays within PlayerJoinClient territory and never leaks
+    // access to /sheet. Real tokens are covered by e2e/combat/player-join
+    // + e2e/journeys/j11-player-view-complete.
+    const bogusToken = "not-a-real-token-baseline-anon-smoke";
+    await page.goto(`/join/${bogusToken}`, {
+      timeout: 30_000,
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForLoadState("domcontentloaded");
+
+    // We don't care HOW the app handles the bad token (error message vs.
+    // redirect vs. form) — we only care that `/sheet` never becomes
+    // accessible as a side effect. The negative assertion is the point.
+    expect(page.url()).not.toMatch(/\/app\/campaigns\/[^/]+\/sheet(?:\?|$)/);
+
+    // PlayerHqShell's tablist role should not render anywhere.
+    const tablist = page.locator('[role="tablist"]');
+    const tabCount = await tablist.count();
+    expect(tabCount).toBe(0);
+  });
+});

--- a/e2e/player-hq/sheet-smoke-guest.spec.ts
+++ b/e2e/player-hq/sheet-smoke-guest.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Player HQ — Guest smoke baseline (EP-INFRA.4, Sprint 1 Track B).
+ *
+ * Documents that `/try` (Guest combat at `app/try/page.tsx` driven by
+ * `components/guest/GuestCombatClient.tsx`) does NOT host or link to the
+ * Player HQ shell at `/app/campaigns/[id]/sheet`. Guest has no persistent
+ * user → no `campaign_members` row → no character → no sheet.
+ *
+ * This is intentional per the Combat Parity Rule. See CLAUDE.md:
+ *   "Data persistence features (ratings, notas, spell slots) → Auth-only,
+ *    documentar no bucket"
+ * The full Player HQ surface hits that rule hard — it IS a persistence
+ * feature. Guest users can only play combat, not the HQ.
+ *
+ * Why a guest-focused baseline is valuable:
+ *   1. Sprint 2 A6 (post-combat redirect) may add a "guest → /sheet?tab=
+ *      heroi" upsell path (decision #43). This spec becomes the checkpoint
+ *      where we validate that change is intentional.
+ *   2. If a future refactor accidentally wires `/try` to load or link to
+ *      `/sheet`, this spec fails with a clear pointer.
+ *
+ * Skip behavior: the test runs purely against `/try` with no auth, no
+ * seed data, no share tokens. Should be stable across all environments.
+ */
+
+test.describe("Player HQ — Guest smoke (no /sheet on /try baseline)", () => {
+  test.setTimeout(45_000);
+
+  test("guest /try session has no PlayerHqShell tablist", async ({ page }) => {
+    await page.goto("/try", { timeout: 30_000, waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("domcontentloaded");
+
+    // Just confirm /try actually loaded — skip if the landing redirected
+    // us (e.g. middleware blocking in an odd env).
+    if (!page.url().includes("/try")) {
+      test.skip(true, `/try redirected to ${page.url()} — cannot run guest baseline`);
+      return;
+    }
+
+    // PlayerHqShell uses `role="tablist"` for its 7-tab shell. If that
+    // ever renders in /try, something is very wrong — guest has no user,
+    // no campaign, no character.
+    const playerHqTablist = page.locator('[role="tablist"]').filter({
+      has: page.locator("#tab-map"),
+    });
+    await expect(playerHqTablist).toHaveCount(0);
+
+    // And none of the individual V1 tab buttons should render in /try.
+    for (const key of ["map", "sheet", "resources", "abilities", "inventory", "notes", "quests"]) {
+      const tab = page.locator(`#tab-${key}`);
+      await expect(tab, `#tab-${key} must NOT render in /try`).toHaveCount(0);
+    }
+  });
+
+  test("guest /try never link-leaks to /sheet routes", async ({ page }) => {
+    await page.goto("/try", { timeout: 30_000, waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("domcontentloaded");
+
+    if (!page.url().includes("/try")) {
+      test.skip(true, `/try redirected to ${page.url()}`);
+      return;
+    }
+
+    // Scan all anchor hrefs on /try for sheet routes. The guest surface
+    // should offer sign-up/login CTAs, never deep links into the auth
+    // Player HQ. If Sprint 2 A6 adds such a link, update this assertion
+    // to the specific expected route (e.g. `/sheet?tab=heroi`) and keep
+    // the negative check for anything else.
+    const links = page.locator("a[href]");
+    const count = await links.count();
+    const hrefs: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const href = await links.nth(i).getAttribute("href");
+      if (href) hrefs.push(href);
+    }
+
+    const sheetLinks = hrefs.filter((h) => /\/app\/campaigns\/[^/]+\/sheet\b/.test(h));
+    expect(sheetLinks, `/try must not link to /sheet — got: ${sheetLinks.join(", ")}`).toEqual([]);
+  });
+});

--- a/e2e/player-hq/sheet-smoke-guest.spec.ts
+++ b/e2e/player-hq/sheet-smoke-guest.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { TAB_KEYS } from "./_constants";
 
 /**
  * Player HQ — Guest smoke baseline (EP-INFRA.4, Sprint 1 Track B).
@@ -35,7 +36,9 @@ test.describe("Player HQ — Guest smoke (no /sheet on /try baseline)", () => {
     // Just confirm /try actually loaded — skip if the landing redirected
     // us (e.g. middleware blocking in an odd env).
     if (!page.url().includes("/try")) {
-      test.skip(true, `/try redirected to ${page.url()} — cannot run guest baseline`);
+      const reason = `/try redirected to ${page.url()} — cannot run guest baseline`;
+      test.info().annotations.push({ type: "skip-reason", description: reason });
+      test.skip(true, reason);
       return;
     }
 
@@ -48,7 +51,7 @@ test.describe("Player HQ — Guest smoke (no /sheet on /try baseline)", () => {
     await expect(playerHqTablist).toHaveCount(0);
 
     // And none of the individual V1 tab buttons should render in /try.
-    for (const key of ["map", "sheet", "resources", "abilities", "inventory", "notes", "quests"]) {
+    for (const key of TAB_KEYS) {
       const tab = page.locator(`#tab-${key}`);
       await expect(tab, `#tab-${key} must NOT render in /try`).toHaveCount(0);
     }
@@ -59,7 +62,9 @@ test.describe("Player HQ — Guest smoke (no /sheet on /try baseline)", () => {
     await page.waitForLoadState("domcontentloaded");
 
     if (!page.url().includes("/try")) {
-      test.skip(true, `/try redirected to ${page.url()}`);
+      const reason = `/try redirected to ${page.url()}`;
+      test.info().annotations.push({ type: "skip-reason", description: reason });
+      test.skip(true, reason);
       return;
     }
 

--- a/e2e/player-hq/sheet-smoke.spec.ts
+++ b/e2e/player-hq/sheet-smoke.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "../helpers/auth";
+import { PLAYER_WARRIOR } from "../fixtures/test-accounts";
+
+/**
+ * Player HQ — Auth smoke baseline (EP-INFRA.4, Sprint 1 Track B).
+ *
+ * Pre-refactor baseline for the 7-tab Player HQ shell at
+ * `/app/campaigns/[id]/sheet`. Captures the current V1 behavior so
+ * Sprint 2+ can detect regressions once `NEXT_PUBLIC_PLAYER_HQ_V2`
+ * starts gating a new 4-tab shell (Herói / Arsenal / Diário / Mapa).
+ *
+ * What this spec DOES assert:
+ *   - `/app/campaigns/[id]/sheet` is reachable after player login
+ *   - Tab list is rendered with `role="tablist"`
+ *   - All 7 V1 tab buttons (map/sheet/resources/abilities/inventory/notes/
+ *     quests) render, each with `role="tab"` and id `tab-{key}`
+ *   - Default active tab is `map` (Tab state in PlayerHqShell.tsx:129)
+ *   - A screenshot is captured for visual-regression baseline later
+ *
+ * What this spec does NOT assert (intentional — see e2e/player-hq/README.md):
+ *   - Tab switching interaction (reserved for Sprint 2 B4/B5 stories)
+ *   - Content correctness inside each tab (owned by active-effects /
+ *     j21-player-ui-panels / j19-player-combat-actions)
+ *   - Feature-flag gating (no call sites yet)
+ *
+ * Skip behavior: if the player account has no character seeded for any
+ * campaign in the current environment, the spec emits `test.skip` with
+ * a clear message rather than failing. This keeps CI green on fresh
+ * deploys where the test-account fixtures aren't yet seeded.
+ */
+
+const TAB_KEYS = [
+  "map",
+  "sheet",
+  "resources",
+  "abilities",
+  "inventory",
+  "notes",
+  "quests",
+] as const;
+
+test.describe("Player HQ — Auth smoke (7-tab shell baseline)", () => {
+  test.setTimeout(90_000);
+
+  test("authenticated player lands on /sheet with 7 tabs rendered", async ({ page }) => {
+    await loginAs(page, PLAYER_WARRIOR);
+
+    // Find a campaign the player is a member of. The dashboard lists
+    // campaigns as links to /app/campaigns/[id].
+    await page.goto("/app/dashboard", { timeout: 60_000, waitUntil: "domcontentloaded" });
+    await page.waitForLoadState("domcontentloaded");
+
+    const campaignLinks = page.locator('a[href^="/app/campaigns/"]');
+    const count = await campaignLinks.count();
+    if (count === 0) {
+      test.skip(true, "No campaigns seeded for PLAYER_WARRIOR in this environment");
+      return;
+    }
+
+    // Extract campaign id from the first link. The sheet route is
+    // `/app/campaigns/{id}/sheet` — navigate there directly.
+    const firstHref = await campaignLinks.first().getAttribute("href");
+    expect(firstHref).toBeTruthy();
+    const match = firstHref?.match(/\/app\/campaigns\/([0-9a-f-]+)/i);
+    if (!match) {
+      test.skip(true, `Could not extract campaign id from href: ${firstHref}`);
+      return;
+    }
+    const campaignId = match[1];
+
+    await page.goto(`/app/campaigns/${campaignId}/sheet`, {
+      timeout: 60_000,
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForLoadState("domcontentloaded");
+
+    // Sheet server component redirects when the user isn't a player with a
+    // seeded character. If that happens, skip — we don't want to fail
+    // baseline tests in environments missing test seed data.
+    if (!page.url().includes("/sheet")) {
+      test.skip(true, `Player redirected from /sheet — URL: ${page.url()}`);
+      return;
+    }
+
+    // Tab list is the foundational assertion. If this fails, the shell is
+    // broken — which is exactly what we want baseline tests to catch.
+    const tablist = page.locator('[role="tablist"]');
+    await expect(tablist).toBeVisible({ timeout: 15_000 });
+
+    // All 7 V1 tabs exist by id — if any of these disappear silently during
+    // the refactor, the diff from baseline will flag it before merge.
+    for (const key of TAB_KEYS) {
+      const tab = page.locator(`#tab-${key}`);
+      await expect(tab, `tab-${key} should be rendered in the V1 shell`).toBeVisible({
+        timeout: 5_000,
+      });
+      await expect(tab).toHaveAttribute("role", "tab");
+    }
+
+    // Default activeTab is `map` per PlayerHqShell.tsx:129 (`useState<Tab>("map")`).
+    // Note: this default MAY change in Sprint 2 B4 — the baseline will force
+    // an explicit decision about whether the change is intentional.
+    const mapTab = page.locator("#tab-map");
+    await expect(mapTab).toHaveAttribute("aria-selected", "true");
+
+    // Baseline screenshot for visual-regression once Sprint 2 starts
+    // producing post-refactor snapshots. Name prefix `pre-refactor-` makes
+    // the before/after comparison obvious in code review.
+    await page.screenshot({
+      path: "e2e/results/pre-refactor-sheet-auth-baseline.png",
+      fullPage: true,
+    });
+  });
+});

--- a/e2e/player-hq/sheet-smoke.spec.ts
+++ b/e2e/player-hq/sheet-smoke.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { loginAs } from "../helpers/auth";
 import { PLAYER_WARRIOR } from "../fixtures/test-accounts";
+import { TAB_KEYS } from "./_constants";
 
 /**
  * Player HQ — Auth smoke baseline (EP-INFRA.4, Sprint 1 Track B).
@@ -30,16 +31,6 @@ import { PLAYER_WARRIOR } from "../fixtures/test-accounts";
  * deploys where the test-account fixtures aren't yet seeded.
  */
 
-const TAB_KEYS = [
-  "map",
-  "sheet",
-  "resources",
-  "abilities",
-  "inventory",
-  "notes",
-  "quests",
-] as const;
-
 test.describe("Player HQ — Auth smoke (7-tab shell baseline)", () => {
   test.setTimeout(90_000);
 
@@ -54,7 +45,9 @@ test.describe("Player HQ — Auth smoke (7-tab shell baseline)", () => {
     const campaignLinks = page.locator('a[href^="/app/campaigns/"]');
     const count = await campaignLinks.count();
     if (count === 0) {
-      test.skip(true, "No campaigns seeded for PLAYER_WARRIOR in this environment");
+      const reason = "No campaigns seeded for PLAYER_WARRIOR in this environment";
+      test.info().annotations.push({ type: "skip-reason", description: reason });
+      test.skip(true, reason);
       return;
     }
 
@@ -64,7 +57,9 @@ test.describe("Player HQ — Auth smoke (7-tab shell baseline)", () => {
     expect(firstHref).toBeTruthy();
     const match = firstHref?.match(/\/app\/campaigns\/([0-9a-f-]+)/i);
     if (!match) {
-      test.skip(true, `Could not extract campaign id from href: ${firstHref}`);
+      const reason = `Could not extract campaign id from href: ${firstHref}`;
+      test.info().annotations.push({ type: "skip-reason", description: reason });
+      test.skip(true, reason);
       return;
     }
     const campaignId = match[1];
@@ -79,7 +74,9 @@ test.describe("Player HQ — Auth smoke (7-tab shell baseline)", () => {
     // seeded character. If that happens, skip — we don't want to fail
     // baseline tests in environments missing test seed data.
     if (!page.url().includes("/sheet")) {
-      test.skip(true, `Player redirected from /sheet — URL: ${page.url()}`);
+      const reason = `Player redirected from /sheet — URL: ${page.url()}`;
+      test.info().annotations.push({ type: "skip-reason", description: reason });
+      test.skip(true, reason);
       return;
     }
 


### PR DESCRIPTION
## Summary

Sprint 1 Track B — pre-refactor Playwright baseline for the 7-tab Player HQ shell at `/app/campaigns/[id]/sheet`. Captures current V1 behavior so Sprint 2+ can detect regressions once `NEXT_PUBLIC_PLAYER_HQ_V2` starts gating the new 4-tab shell (Herói / Arsenal / Diário / Mapa).

## What's in this PR

Three new Playwright spec files covering all three access modes, plus a README scoping what's in/out:

- **`e2e/player-hq/sheet-smoke.spec.ts`** (Auth) — Logs in as `PLAYER_WARRIOR`, finds a seeded campaign from the dashboard, navigates to `/app/campaigns/[id]/sheet`, asserts:
  - `[role="tablist"]` visible
  - All 7 V1 tabs (`#tab-map`, `#tab-sheet`, `#tab-resources`, `#tab-abilities`, `#tab-inventory`, `#tab-notes`, `#tab-quests`) render
  - Default `#tab-map` has `aria-selected="true"` (matches `PlayerHqShell.tsx:129`)
  - Saves `e2e/results/pre-refactor-sheet-auth-baseline.png` full-page screenshot
  - Skips gracefully if the player account has no seeded campaign (keeps CI green on fresh deploys).
- **`e2e/player-hq/sheet-smoke-anon.spec.ts`** — Documents the intentional gap that anon visitors cannot reach `/sheet` (server-component redirect when `user` is null). Two negative assertions: direct `/sheet` visit redirects away + `/join/[invalid-token]` never leaks `/sheet` access.
- **`e2e/player-hq/sheet-smoke-guest.spec.ts`** — Documents the intentional gap that guest `/try` has no `PlayerHqShell` and no links to `/sheet`. Two negative assertions: no `role=\"tablist\"` with `#tab-map` present + no `<a>` on `/try` pointing to a sheet route.
- **`e2e/player-hq/README.md`** — scope, run commands, intentional non-goals.

## Local verification (all green where runnable)

```
npx playwright test e2e/player-hq/sheet-smoke-guest.spec.ts --project=desktop-chrome
  2 passed (13.3s)

npx playwright test e2e/player-hq/sheet-smoke-anon.spec.ts --project=desktop-chrome
  2 passed (9.0s)

npx playwright test e2e/player-hq/sheet-smoke.spec.ts --project=desktop-chrome
  1 skipped  # PLAYER_WARRIOR not seeded in local env — expected
```

`npx playwright test --list e2e/player-hq/` shows 10 tests (5 specs × 2 projects: desktop-chrome + mobile-safari).

## Why this scaffolding matters

From `_bmad-output/party-mode-2026-04-22/15-e2e-matrix.md`: today only 2 spec files touch `/sheet` (the active-effects family) and they cover feature lifecycle, not shell topology. This PR creates the missing foundation: a cheap, always-runnable smoke check that the shell rendered correctly in V1 — so Sprint 2 Gate Fase A (`sheet-visual-baseline.spec.ts`, `sheet-ability-chips-always-visible.spec.ts`, etc.) has something to diff against.

## Intentional non-goals

- **Tab switching interaction** — reserved for Sprint 2+ when B5 deep-links and B4 persistence land.
- **Content correctness inside each tab** — owned by `active-effects*.spec.ts`, `j21-player-ui-panels.spec.ts`, `j19-player-combat-actions.spec.ts`.
- **Feature-flag gating** — the V2 flag has zero call sites as of Sprint 1; assertions tied to it appear in Sprint 2+ once `isPlayerHqV2Enabled()` is consumed.

## Test plan

- [x] `rtk tsc --noEmit` — clean
- [x] Playwright can list all 10 tests (5 × 2 projects)
- [x] Guest specs pass against local dev (2/2, 13s)
- [x] Anon specs pass against local dev (2/2, 9s)
- [x] Auth spec skips gracefully when fixture not seeded — documented behavior
- [ ] CI: spec files run under the existing `e2e.yml` workflow as part of the broader Playwright matrix

## References

- [`_bmad-output/party-mode-2026-04-22/15-e2e-matrix.md`](../blob/master/_bmad-output/party-mode-2026-04-22/15-e2e-matrix.md) §\"Current coverage inventory\" and §\"Parity gaps\"
- [`_bmad-output/party-mode-2026-04-22/14-sprint-plan.md`](../blob/master/_bmad-output/party-mode-2026-04-22/14-sprint-plan.md) Sprint 1 Track B item 4

Closes EP-INFRA.4.

<!-- parity-intent
guest: covered (sheet-smoke-guest.spec.ts)
anon: covered (sheet-smoke-anon.spec.ts)
auth: covered (sheet-smoke.spec.ts)
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)