### PR TITLE
fix(conversion): restore anon player CTA gate via is_anonymous check

### DIFF
--- a/components/player/PlayerJoinClient.test.tsx
+++ b/components/player/PlayerJoinClient.test.tsx
@@ -5,8 +5,24 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { PlayerJoinClient } from "./PlayerJoinClient";
 
+// Mock next/navigation — PlayerJoinClient:212 calls useRouter() on mount.
+// Without this mock every test throws "invariant expected app router to be mounted".
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    prefetch: jest.fn(),
+    back: jest.fn(),
+    forward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  usePathname: () => "/join/token-123",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 // Mock supabase client
 const mockGetSession = jest.fn();
+const mockGetUser = jest.fn();
 const mockSignInAnonymously = jest.fn();
 const mockChannel = jest.fn();
 const mockRemoveChannel = jest.fn();
@@ -15,6 +31,7 @@ jest.mock("@/lib/supabase/client", () => ({
   createClient: () => ({
     auth: {
       getSession: mockGetSession,
+      getUser: mockGetUser,
       signInAnonymously: mockSignInAnonymously,
     },
     channel: mockChannel,
@@ -95,6 +112,9 @@ describe("PlayerJoinClient", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetSession.mockResolvedValue({ data: { session: null } });
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "anon-user-1", is_anonymous: true } },
+    });
     mockSignInAnonymously.mockResolvedValue({
       data: { user: { id: "anon-user-1" } },
       error: null,
@@ -292,5 +312,53 @@ describe("PlayerJoinClient", () => {
 
     // Should NOT have called registerPlayerCombatant (already registered)
     expect(mockRegisterPlayerCombatant).not.toHaveBeenCalled();
+  });
+
+  describe("isAnonPlayer gating (regression: 2026-04-24)", () => {
+    // `join.waiting-room.auth-cta` ("Já tenho conta") is the simplest gate:
+    // visible iff `isAnonPlayer === true`. Regression cause: pre-fix
+    // `isAnonPlayer = !authUserId` always returned false (anon users have UID).
+    it("anon user (is_anonymous=true) SEES the auth-cta button", async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: { id: "anon-user-1", is_anonymous: true } },
+      });
+
+      render(<PlayerJoinClient {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mock-player-lobby")).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByTestId("join.waiting-room.auth-cta")).toBeInTheDocument();
+      });
+    });
+
+    it("real authenticated user (is_anonymous=false) does NOT see the auth-cta button", async () => {
+      mockGetSession.mockResolvedValue({
+        data: { session: { user: { id: "real-user-99" } } },
+      });
+      mockGetUser.mockResolvedValue({
+        data: { user: { id: "real-user-99", is_anonymous: false } },
+      });
+
+      render(<PlayerJoinClient {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mock-player-lobby")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("join.waiting-room.auth-cta")).not.toBeInTheDocument();
+    });
+
+    it("null user during boot window does NOT flash the auth-cta button", async () => {
+      // getUser never resolves → isRealAuthUser stays null → isAnonPlayer stays false
+      mockGetUser.mockReturnValue(new Promise(() => {}));
+
+      render(<PlayerJoinClient {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId("mock-player-lobby")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("join.waiting-room.auth-cta")).not.toBeInTheDocument();
+    });
   });
 });

--- a/components/player/PlayerJoinClient.tsx
+++ b/components/player/PlayerJoinClient.tsx
@@ -3285,7 +3285,12 @@ export function PlayerJoinClient({
   // unmounts the PlayerLobby / PlayerInitiativeBoard — preserving realtime
   // channels, storage listeners, and the heartbeat interval. (Wave 0 ACs.)
   // ─────────────────────────────────────────────────────────────────────
-  const isAnonPlayer = !authUserId;
+  // Canonical auth check — `signInAnonymously()` returns a real Supabase UID,
+  // so `!authUserId` treats anon users as authenticated (bug: 2026-04-20..2026-04-24).
+  // Use `is_anonymous` semantics via isRealAuthUser (derivação em :697).
+  // `isRealAuthUser === null` during the auth boot window renders as "not anon"
+  // to avoid a flash of conversion CTAs before auth resolves.
+  const isAnonPlayer = isRealAuthUser === false;
   const dismissalCampaignId = campaignId ?? sessionCampaignId ?? "__guest__";
   const effectiveUpgradeCampaignId = campaignId ?? sessionCampaignId;
   // Q#4 — `shouldShowCta` reads. Re-evaluates on dismissalVersion bumps

--- a/e2e/invite/anon-to-auth-via-join.spec.ts
+++ b/e2e/invite/anon-to-auth-via-join.spec.ts
@@ -131,22 +131,17 @@ test.describe("E2E — Anon player upgrades to auth via /join CTA banner", () =>
 
     await page.locator('[data-testid="lobby-submit"]').click();
 
-    // ── 2. CTA banner must appear (Story 02-E WaitingRoomSignupCTA) ──
-    // Testid contract §3.5: join.signup-cta.banner
-    const ctaBanner = page.locator('[data-testid="join.signup-cta.banner"]');
-    const legacyCtaWrapper = page.locator('[data-testid="join.signup-cta"]');
-
-    const hasCta = await ctaBanner
-      .or(legacyCtaWrapper)
-      .first()
-      .waitFor({ state: "visible", timeout: 15_000 })
-      .then(() => true)
-      .catch(() => false);
-
-    test.skip(
-      !hasCta,
-      "WaitingRoomSignupCTA not yet deployed — re-run after Story 02-E",
-    );
+    // ── 2. CTA banner must appear (Story 03-C WaitingRoomSignupCTA) ──
+    // Canonical testid: `conversion.waiting-room-cta` (components/conversion/WaitingRoomSignupCTA.tsx).
+    // Legacy testids `join.signup-cta.banner` / `join.signup-cta` kept only as fallback until removal.
+    // HARD ASSERT — if CTA doesn't render, test FAILS. A `test.skip` here is what let
+    // the 2026-04-20→24 regression (`isAnonPlayer = !authUserId`) ship silently.
+    const ctaCanonical = page.locator('[data-testid="conversion.waiting-room-cta"]');
+    const ctaLegacyBanner = page.locator('[data-testid="join.signup-cta.banner"]');
+    const ctaLegacyWrapper = page.locator('[data-testid="join.signup-cta"]');
+    await expect(
+      ctaCanonical.or(ctaLegacyBanner).or(ctaLegacyWrapper).first(),
+    ).toBeVisible({ timeout: 15_000 });
 
     // ── 3. Capture session_token_id BEFORE upgrade ──
     const preUpgradeTokenId = await readSessionTokenId(page);
@@ -160,7 +155,9 @@ test.describe("E2E — Anon player upgrades to auth via /join CTA banner", () =>
     }
 
     // ── 4. Click CTA → AuthModal opens with upgrade context ──
-    const primaryCtaBtn = page.locator('[data-testid="join.signup-cta.primary-button"]');
+    const primaryCanonical = page.locator('[data-testid="conversion.waiting-room-cta.primary"]');
+    const primaryLegacy = page.locator('[data-testid="join.signup-cta.primary-button"]');
+    const primaryCtaBtn = primaryCanonical.or(primaryLegacy).first();
     await expect(primaryCtaBtn).toBeVisible({ timeout: 5_000 });
     await primaryCtaBtn.click();
 

--- a/e2e/invite/auth-user-no-conversion-cta.spec.ts
+++ b/e2e/invite/auth-user-no-conversion-cta.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * e2e/invite/auth-user-no-conversion-cta.spec.ts
+ *
+ * Negative invariant for the 2026-04-24 regression:
+ *   `isAnonPlayer = !authUserId` → `isRealAuthUser === false`.
+ *
+ * This spec is the mirror of `anon-to-auth-via-join.spec.ts`:
+ *
+ *   An ALREADY-AUTHENTICATED player visits /join/[token] → PlayerJoinClient
+ *   reuses the existing session (no signInAnonymously) → isRealAuthUser === true
+ *   → isAnonPlayer === false → NO conversion CTAs render.
+ *
+ * Guards against the inverse regression — CTA showing up for real auth users,
+ * which would be spammy and would also indicate the gate drifted again.
+ *
+ * Requires the same environment as the positive spec:
+ *   - NEXT_PUBLIC_E2E_MODE=true
+ *   - E2E_CAMPAIGN_ID_ACTIVE or E2E_JOIN_TOKEN
+ *
+ * Skips cleanly if env missing.
+ */
+
+import { test, expect } from "@playwright/test";
+import { PLAYER_WARRIOR } from "../fixtures/test-accounts";
+import { loginAs } from "../helpers/auth";
+import { seedSessionToken, cleanup, createCleanupContext, type CleanupPayload } from "../helpers/identity-fixtures";
+
+const CAMPAIGN_ID_WITH_ACTIVE_SESSION = process.env.E2E_CAMPAIGN_ID_ACTIVE;
+const FALLBACK_JOIN_TOKEN = process.env.E2E_JOIN_TOKEN;
+
+test.describe("E2E — Authenticated player on /join does NOT see conversion CTAs", () => {
+  test.setTimeout(90_000);
+
+  const cleanupCtx: CleanupPayload = createCleanupContext();
+
+  test.skip(
+    !CAMPAIGN_ID_WITH_ACTIVE_SESSION && !FALLBACK_JOIN_TOKEN,
+    "Neither E2E_CAMPAIGN_ID_ACTIVE nor E2E_JOIN_TOKEN set",
+  );
+
+  test.afterAll(async ({ browser }) => {
+    if (!cleanupCtx.sessionTokenIds?.length) return;
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    try {
+      await cleanup(page, cleanupCtx);
+    } catch (err) {
+      console.warn("[auth-user-no-conversion-cta] cleanup failed:", err);
+    } finally {
+      await ctx.close().catch(() => {});
+    }
+  });
+
+  test("real auth user joins session → no waiting-room CTA, no auth-cta button, no signup-hint", async ({
+    page,
+  }) => {
+    // ── 1. Login as a real authenticated player BEFORE visiting /join ──
+    await loginAs(page, PLAYER_WARRIOR);
+
+    // ── 2. Obtain a join token (same seeding as positive spec) ──
+    let joinToken: string;
+    if (CAMPAIGN_ID_WITH_ACTIVE_SESSION) {
+      const seeded = await seedSessionToken(
+        page,
+        CAMPAIGN_ID_WITH_ACTIVE_SESSION,
+        "Auth Player Warrior",
+      );
+      joinToken = seeded.token;
+      cleanupCtx.sessionTokenIds!.push(seeded.sessionTokenId);
+    } else {
+      joinToken = FALLBACK_JOIN_TOKEN!;
+    }
+
+    // ── 3. Navigate to /join/[token] ──
+    await page.goto(`/join/${joinToken}`);
+    await page.waitForLoadState("domcontentloaded");
+
+    const waitingRoom = page.locator('[data-testid="join.waiting-room"]');
+    await expect(waitingRoom).toBeVisible({ timeout: 30_000 });
+
+    // ── 4. Fill lobby ──
+    const nameInput = page.locator('[data-testid="lobby-name"]');
+    await expect(nameInput).toBeVisible({ timeout: 10_000 });
+    await nameInput.fill("Auth Player Warrior");
+
+    const initInput = page.locator('[data-testid="lobby-initiative"]');
+    if (await initInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await initInput.fill("14");
+    }
+
+    await page.locator('[data-testid="lobby-submit"]').click();
+
+    // ── 5. Give the UI ~3s to render any CTA that would have appeared ──
+    await page.waitForTimeout(3_000);
+
+    // ── 6. Hard assert: NONE of the three conversion surfaces are present ──
+    await expect(
+      page.locator('[data-testid="conversion.waiting-room-cta"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-testid="join.waiting-room.auth-cta"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-testid="join.signup-hint-banner"]'),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

`isAnonPlayer = !authUserId` sempre retornava `false` pra jogadores anônimos em `/join` porque `signInAnonymously()` cria um UID real. O bug silenciosamente suprimiu **3 CTAs** desde o merge de Story 03-C em 2026-04-20:

- `WaitingRoomSignupCTA` — card "Salvar {characterName}" na sala de espera
- Botão "Já tenho conta" (`join.waiting-room.auth-cta`)
- Signup-hint-banner

Fix usa `isRealAuthUser === false` (semântica canônica via `is_anonymous`).

## Test coverage

- **Unit**: 3 cenários de regressão em `PlayerJoinClient.test.tsx`
- **E2E Anon**: `anon-to-auth-via-join` hardened — removido `test.skip(!hasCta, ...)`
- **E2E Auth**: novo `auth-user-no-conversion-cta.spec.ts` (invariante inverso)

## Bonus

Mock de `useRouter` destrava 11 testes pré-existentes do `PlayerJoinClient`.

## Long-term risk mitigated

Sem CTA, todo jogador de beta criava nova `auth.users` row a cada sessão. Postmortem de 2026-04-24 documentou "13 session_tokens em uma sessão (6 nomeados + 7 sombras anon)". Bug era acelerador direto desse vetor.

<!-- parity-intent
guest: n/a (bug é 100% no fluxo /join anon; guest users em /try usam GuestCombatClient, não PlayerJoinClient — fora do código modificado)
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)