### PR TITLE
perf(combat): coalesce /state queries with per-kind TTLs (postmortem R3)

### DIFF
--- a/app/api/combat/[id]/state/route.ts
+++ b/app/api/combat/[id]/state/route.ts
@@ -3,8 +3,41 @@ import { createClient, createServiceClient } from "@/lib/supabase/server";
 import { sanitizeCombatantsForPlayer } from "@/lib/utils/sanitize-combatants";
 import { captureError } from "@/lib/errors/capture";
 import { withRateLimit } from "@/lib/rate-limit";
+import { coalesce } from "@/lib/cache/request-coalesce";
+import { isFeatureFlagEnabled } from "@/lib/flags";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Per-kind TTLs from the 2026-04-24 postmortem (§Causa #2). Combatants are
+ * the only genuinely hot path — everything else mutates orders-of-magnitude
+ * slower than the 2s polling cadence.
+ *
+ * TOKEN_TTL_MS: 15s — the canonical trade-off. A DM revoking a token (setting
+ * `is_active = false`) loses up to 15s of immediacy. No active revocation
+ * flow exists in-code as of this commit; when one is added, call
+ * `invalidate("tok:{sessionId}:{userId}")` from `lib/cache/request-coalesce`
+ * to bust the cache explicitly.
+ */
+const TTL = {
+  TOKEN_MS: 15_000,
+  SESSION_MS: 10_000,
+  ENCOUNTER_MS: 5_000,
+  TOKEN_OWNER_MS: 60_000,
+  LOBBY_TOKENS_MS: 5_000,
+} as const;
+
+type SessionTokenRow = { id: string } | null;
+type SessionRow = {
+  dm_plan: string | null;
+  dm_last_seen_at: string | null;
+} | null;
+type EncounterRow = {
+  id: string;
+  round_number: number;
+  current_turn_index: number;
+  is_active: boolean;
+} | null;
 
 const handler: Parameters<typeof withRateLimit>[0] = async function getHandler(
   request: NextRequest,
@@ -28,73 +61,123 @@ const handler: Parameters<typeof withRateLimit>[0] = async function getHandler(
   }
 
   try {
-    // Use service client to bypass RLS for token/session/encounter lookups
-    // (anonymous players can't read these tables through RLS)
     const serviceClient = createServiceClient();
+    const coalesceEnabled = isFeatureFlagEnabled("ff_combat_state_coalesce_v1");
 
-    // Batch: token check + session fetch + encounter fetch run in parallel
-    const [tokenResult, sessionResult, encounterResult] = await Promise.all([
-      // Check if user has a valid session token
-      serviceClient
-        .from("session_tokens")
-        .select("id")
-        .eq("session_id", sessionId)
-        .eq("anon_user_id", user.id)
-        .eq("is_active", true)
-        .limit(1)
-        .single(),
-      // Fetch dm_plan + dm_last_seen_at from sessions table
-      serviceClient
-        .from("sessions")
-        .select("dm_plan, dm_last_seen_at")
-        .eq("id", sessionId)
-        .single(),
-      // Fetch active encounter
-      serviceClient
-        .from("encounters")
-        .select("id, round_number, current_turn_index, is_active")
-        .eq("session_id", sessionId)
-        .eq("is_active", true)
-        .order("created_at", { ascending: false })
-        .limit(1)
-        .single(),
-    ]);
+    // ────────────────────────────────────────────────────────────────────
+    // Queries 1-3 in parallel. When coalesce is enabled, cache keys scope
+    // by (kind, sessionId[, userId|tokenIdParam]) with per-kind TTLs.
+    // ────────────────────────────────────────────────────────────────────
+    const tokenPromise: Promise<SessionTokenRow> = coalesceEnabled
+      ? coalesce(`tok:${sessionId}:${user.id}`, TTL.TOKEN_MS, async () => {
+          const { data, error } = await serviceClient
+            .from("session_tokens")
+            .select("id")
+            .eq("session_id", sessionId)
+            .eq("anon_user_id", user.id)
+            .eq("is_active", true)
+            .limit(1)
+            .single();
+          // Re-throw anything that isn't "zero rows" so callers can capture.
+          if (error && error.code !== "PGRST116") throw error;
+          return (data ?? null) as SessionTokenRow;
+        })
+      : (async () => {
+          const { data, error } = await serviceClient
+            .from("session_tokens")
+            .select("id")
+            .eq("session_id", sessionId)
+            .eq("anon_user_id", user.id)
+            .eq("is_active", true)
+            .limit(1)
+            .single();
+          if (error && error.code !== "PGRST116") throw error;
+          return (data ?? null) as SessionTokenRow;
+        })();
 
-    const { data: tokenRow, error: tokenError } = tokenResult;
+    const sessionPromise: Promise<SessionRow> = coalesceEnabled
+      ? coalesce(`ses:${sessionId}`, TTL.SESSION_MS, async () => {
+          const { data, error } = await serviceClient
+            .from("sessions")
+            .select("dm_plan, dm_last_seen_at")
+            .eq("id", sessionId)
+            .single();
+          if (error && error.code !== "PGRST116") throw error;
+          return (data ?? null) as SessionRow;
+        })
+      : (async () => {
+          const { data, error } = await serviceClient
+            .from("sessions")
+            .select("dm_plan, dm_last_seen_at")
+            .eq("id", sessionId)
+            .single();
+          if (error && error.code !== "PGRST116") throw error;
+          return (data ?? null) as SessionRow;
+        })();
 
-    // PGRST116 = "0 rows" — not a DB failure, just no matching token
-    if (tokenError && tokenError.code !== "PGRST116") {
-      captureError(tokenError, { component: "SessionStateAPI", action: "verifyToken", category: "database" });
-      return NextResponse.json({ error: "Failed to verify access" }, { status: 500 });
+    const encounterPromise: Promise<EncounterRow> = coalesceEnabled
+      ? coalesce(`enc:${sessionId}`, TTL.ENCOUNTER_MS, async () => {
+          const { data, error } = await serviceClient
+            .from("encounters")
+            .select("id, round_number, current_turn_index, is_active")
+            .eq("session_id", sessionId)
+            .eq("is_active", true)
+            .order("created_at", { ascending: false })
+            .limit(1)
+            .single();
+          if (error && error.code !== "PGRST116") throw error;
+          return (data ?? null) as EncounterRow;
+        })
+      : (async () => {
+          const { data, error } = await serviceClient
+            .from("encounters")
+            .select("id, round_number, current_turn_index, is_active")
+            .eq("session_id", sessionId)
+            .eq("is_active", true)
+            .order("created_at", { ascending: false })
+            .limit(1)
+            .single();
+          if (error && error.code !== "PGRST116") throw error;
+          return (data ?? null) as EncounterRow;
+        })();
+
+    let tokenRow: SessionTokenRow;
+    let sessionRow: SessionRow;
+    let encounter: EncounterRow;
+    try {
+      [tokenRow, sessionRow, encounter] = await Promise.all([
+        tokenPromise,
+        sessionPromise,
+        encounterPromise,
+      ]);
+    } catch (err) {
+      captureError(err, { component: "SessionStateAPI", action: "batchFetch", category: "database" });
+      return NextResponse.json({ error: "Failed to fetch session state" }, { status: 500 });
     }
+
     if (!tokenRow) {
       return NextResponse.json({ error: "Access denied" }, { status: 403 });
     }
 
-    // Check session/encounter errors (PGRST116 = "0 rows" is OK — means no active encounter)
-    if (sessionResult.error && sessionResult.error.code !== "PGRST116") {
-      captureError(sessionResult.error, { component: "SessionStateAPI", action: "fetchSession", category: "database" });
-      return NextResponse.json({ error: "Failed to fetch session" }, { status: 500 });
-    }
-    if (encounterResult.error && encounterResult.error.code !== "PGRST116") {
-      captureError(encounterResult.error, { component: "SessionStateAPI", action: "fetchEncounter", category: "database" });
-      return NextResponse.json({ error: "Failed to fetch encounter" }, { status: 500 });
-    }
-
-    const sessionRow = sessionResult.data;
-    const encounter = encounterResult.data;
-
-    // Fire token_owner + combatants in parallel (both depend on earlier results)
-    const tokenOwnerPromise = (tokenIdParam && UUID_RE.test(tokenIdParam))
-      ? serviceClient
-          .from("session_tokens")
-          .select("anon_user_id")
-          .eq("id", tokenIdParam)
-          .eq("session_id", sessionId)
-          .eq("is_active", true)
-          .single()
-          .then(({ data }) => data?.anon_user_id ?? null)
-      : Promise.resolve(null);
+    // ────────────────────────────────────────────────────────────────────
+    // Token owner + combatants in parallel. Combatants are NEVER cached —
+    // HP/conditions/is_defeated are the hot path.
+    // ────────────────────────────────────────────────────────────────────
+    const fetchTokenOwner = async (): Promise<string | null> => {
+      if (!tokenIdParam || !UUID_RE.test(tokenIdParam)) return null;
+      const { data } = await serviceClient
+        .from("session_tokens")
+        .select("anon_user_id")
+        .eq("id", tokenIdParam)
+        .eq("session_id", sessionId)
+        .eq("is_active", true)
+        .single();
+      return data?.anon_user_id ?? null;
+    };
+    const tokenOwnerPromise: Promise<string | null> =
+      coalesceEnabled && tokenIdParam && UUID_RE.test(tokenIdParam)
+        ? coalesce(`own:${sessionId}:${tokenIdParam}`, TTL.TOKEN_OWNER_MS, fetchTokenOwner)
+        : fetchTokenOwner();
 
     const combatantsPromise = encounter
       ? serviceClient
@@ -113,15 +196,37 @@ const handler: Parameters<typeof withRateLimit>[0] = async function getHandler(
 
     if (!encounter) {
       // BT2-04: Include active session tokens so the lobby can show waiting players
-      const { data: tokens } = await serviceClient
-        .from("session_tokens")
-        .select("id, player_name")
-        .eq("session_id", sessionId)
-        .eq("is_active", true)
-        .order("created_at", { ascending: true })
-        .limit(50);
+      const lobbyTokensPromise = coalesceEnabled
+        ? coalesce(`lob:${sessionId}`, TTL.LOBBY_TOKENS_MS, async () => {
+            const { data } = await serviceClient
+              .from("session_tokens")
+              .select("id, player_name")
+              .eq("session_id", sessionId)
+              .eq("is_active", true)
+              .order("created_at", { ascending: true })
+              .limit(50);
+            return data ?? [];
+          })
+        : serviceClient
+            .from("session_tokens")
+            .select("id, player_name")
+            .eq("session_id", sessionId)
+            .eq("is_active", true)
+            .order("created_at", { ascending: true })
+            .limit(50)
+            .then(({ data }) => data ?? []);
+      const tokens = await lobbyTokensPromise;
 
-      return NextResponse.json({ data: { encounter: null, combatants: [], dm_plan: sessionRow?.dm_plan ?? null, dm_last_seen_at: sessionRow?.dm_last_seen_at ?? null, token_owner: tokenOwner, lobby_players: tokens ?? [] } });
+      return NextResponse.json({
+        data: {
+          encounter: null,
+          combatants: [],
+          dm_plan: sessionRow?.dm_plan ?? null,
+          dm_last_seen_at: sessionRow?.dm_last_seen_at ?? null,
+          token_owner: tokenOwner,
+          lobby_players: tokens,
+        },
+      });
     }
 
     // Strip sensitive data from monsters — players see only HP status label.

--- a/lib/cache/request-coalesce.test.ts
+++ b/lib/cache/request-coalesce.test.ts
@@ -77,4 +77,22 @@ describe("request-coalesce", () => {
     await expect(coalesce("k1", 1_000, producer)).rejects.toBe(boom);
     expect(producer).toHaveBeenCalledTimes(1);
   });
+
+  it("LRU-evicts oldest entries when cap exceeded with nothing expired", async () => {
+    // All entries have 60s TTL so nothing expires during the test.
+    // Fill beyond MAX_ENTRIES (1000) and assert oldest keys got evicted.
+    const producer = jest.fn(async (n: number) => n);
+
+    for (let i = 0; i < 1050; i++) {
+      await coalesce(`k${i}`, 60_000, () => producer(i));
+    }
+
+    // The first ~100 keys should be evicted (10% of 1000). Pick key 10:
+    // forcing a new coalesce call must re-fire the producer.
+    const before = producer.mock.calls.length;
+    await coalesce("k10", 60_000, () => producer(10));
+    const after = producer.mock.calls.length;
+
+    expect(after).toBe(before + 1);
+  });
 });

--- a/lib/cache/request-coalesce.test.ts
+++ b/lib/cache/request-coalesce.test.ts
@@ -1,0 +1,80 @@
+import { coalesce, invalidate, invalidatePrefix, __resetForTests } from "./request-coalesce";
+
+describe("request-coalesce", () => {
+  beforeEach(() => {
+    __resetForTests();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("calls producer on first miss and caches the result", async () => {
+    const producer = jest.fn().mockResolvedValue({ id: "A" });
+    const v1 = await coalesce("k1", 1_000, producer);
+    const v2 = await coalesce("k1", 1_000, producer);
+
+    expect(v1).toEqual({ id: "A" });
+    expect(v2).toEqual({ id: "A" });
+    expect(producer).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fires producer after TTL expires", async () => {
+    const producer = jest
+      .fn()
+      .mockResolvedValueOnce({ id: "A" })
+      .mockResolvedValueOnce({ id: "B" });
+
+    const v1 = await coalesce("k1", 1_000, producer);
+    expect(v1).toEqual({ id: "A" });
+
+    jest.advanceTimersByTime(1_500);
+
+    const v2 = await coalesce("k1", 1_000, producer);
+    expect(v2).toEqual({ id: "B" });
+    expect(producer).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidate() forces the next call to re-fire producer", async () => {
+    const producer = jest
+      .fn()
+      .mockResolvedValueOnce("v1")
+      .mockResolvedValueOnce("v2");
+
+    await coalesce("k1", 60_000, producer);
+    invalidate("k1");
+    const v2 = await coalesce("k1", 60_000, producer);
+
+    expect(v2).toBe("v2");
+    expect(producer).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidatePrefix() clears all keys with prefix", async () => {
+    const producer1 = jest.fn().mockResolvedValueOnce("a").mockResolvedValueOnce("a2");
+    const producer2 = jest.fn().mockResolvedValueOnce("b").mockResolvedValueOnce("b2");
+    const producer3 = jest.fn().mockResolvedValueOnce("c");
+
+    await coalesce("ses:123:a", 60_000, producer1);
+    await coalesce("ses:123:b", 60_000, producer2);
+    await coalesce("tok:456:c", 60_000, producer3);
+
+    invalidatePrefix("ses:123:");
+
+    await coalesce("ses:123:a", 60_000, producer1);
+    await coalesce("ses:123:b", 60_000, producer2);
+    await coalesce("tok:456:c", 60_000, producer3);
+
+    expect(producer1).toHaveBeenCalledTimes(2);
+    expect(producer2).toHaveBeenCalledTimes(2);
+    expect(producer3).toHaveBeenCalledTimes(1); // untouched
+  });
+
+  it("does not swallow producer rejections", async () => {
+    const boom = new Error("db down");
+    const producer = jest.fn().mockRejectedValue(boom);
+
+    await expect(coalesce("k1", 1_000, producer)).rejects.toBe(boom);
+    expect(producer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/cache/request-coalesce.ts
+++ b/lib/cache/request-coalesce.ts
@@ -75,4 +75,16 @@ function maybeSweep(now: number): void {
   for (const [k, v] of store) {
     if (v.expiresAt < now) store.delete(k);
   }
+  // LRU fallback — if nothing expired (all entries still fresh, which can
+  // happen under high key churn within a single TTL window), evict oldest
+  // 10% by insertion order. JS Map preserves insertion order, so the first
+  // keys are the oldest. Bounds memory at MAX_ENTRIES * 1.1 worst case.
+  if (store.size > MAX_ENTRIES) {
+    const toEvict = Math.floor(MAX_ENTRIES * 0.1);
+    let i = 0;
+    for (const k of store.keys()) {
+      if (i++ >= toEvict) break;
+      store.delete(k);
+    }
+  }
 }

--- a/lib/cache/request-coalesce.ts
+++ b/lib/cache/request-coalesce.ts
@@ -1,0 +1,78 @@
+/**
+ * In-memory request coalescing with per-key TTL.
+ *
+ * Purpose: reduce pool pressure on hot polling routes (primarily
+ * `/api/combat/[id]/state`) identified as Causa #2 in the
+ * `docs/postmortem-supabase-cdc-pool-exhaustion-2026-04-24.md`. Each request
+ * on that route fires 5 parallel queries via `Promise.all`; 4 of the 5 touch
+ * data that mutates orders-of-magnitude slower than the 2s polling cadence.
+ *
+ * Scope: single Node.js process. Vercel runs multiple serverless instances,
+ * so each instance has its own cache. That's fine — the goal is pressure
+ * reduction, not strict consistency. Expiration is per-key, not global.
+ *
+ * Safety properties:
+ *   - Single-flight-LITE: two concurrent misses may double-fire the producer.
+ *     Acceptable trade-off — the second miss just rewrites an identical value.
+ *   - Bounded growth: ≤1000 entries; on overflow we sweep expired entries.
+ *   - Manual invalidation: `invalidate(key)` / `invalidatePrefix(prefix)` for
+ *     the "bust signal" contract (Dani decision 1c, 2026-04-24 — 15s token
+ *     TTL with explicit invalidation when/if a revocation flow is added).
+ */
+
+type Entry<T> = { value: T; expiresAt: number };
+
+const store = new Map<string, Entry<unknown>>();
+const MAX_ENTRIES = 1000;
+
+export async function coalesce<T>(
+  key: string,
+  ttlMs: number,
+  producer: () => Promise<T>,
+): Promise<T> {
+  const now = Date.now();
+  const hit = store.get(key) as Entry<T> | undefined;
+  if (hit && hit.expiresAt > now) return hit.value;
+
+  const value = await producer();
+  store.set(key, { value, expiresAt: now + ttlMs });
+  maybeSweep(now);
+  return value;
+}
+
+/**
+ * Invalidate a specific key. Call this when you mutate the underlying data
+ * in a way that must be visible immediately — e.g. a DM revokes a player
+ * token (`session_tokens.is_active = false`) and the player must lose access
+ * within <polling-interval> rather than up to TTL seconds later.
+ *
+ * No-op if the key isn't cached.
+ */
+export function invalidate(key: string): void {
+  store.delete(key);
+}
+
+/**
+ * Invalidate all keys that start with `prefix`. Useful for batch busts like
+ * "all cached rows for sessionId X" without tracking per-user keys.
+ */
+export function invalidatePrefix(prefix: string): void {
+  for (const k of store.keys()) {
+    if (k.startsWith(prefix)) store.delete(k);
+  }
+}
+
+/**
+ * Test helper — wipe the cache between test cases. Not exported for
+ * production use.
+ */
+export function __resetForTests(): void {
+  store.clear();
+}
+
+function maybeSweep(now: number): void {
+  if (store.size <= MAX_ENTRIES) return;
+  for (const [k, v] of store) {
+    if (v.expiresAt < now) store.delete(k);
+  }
+}

--- a/lib/flags.ts
+++ b/lib/flags.ts
@@ -29,7 +29,12 @@ export type FeatureFlagKey =
   /** S5.2 Beta 4 P0 — shared Zustand store for favorites (rate-limit storm fix). */
   | "ff_favorites_v2_shared_state"
   /** S5.1 — Polymorph / Wild Shape with two HP bars (reserved; default OFF). */
-  | "ff_polymorph_v1";
+  | "ff_polymorph_v1"
+  /** 2026-04-24 postmortem R3 — coalesce /api/combat/[id]/state queries with
+   * per-kind TTLs (token 15s, session 10s, encounter 5s, token_owner 60s).
+   * Default ON in prod; env var flips it off without redeploy if anything
+   * surprises us in the wild. */
+  | "ff_combat_state_coalesce_v1";
 
 /**
  * Hard-coded defaults. Flipped to `true` on 2026-04-19 for beta 4 soak —
@@ -48,6 +53,7 @@ const DEFAULTS: Record<FeatureFlagKey, boolean> = {
   ff_favorites_v1: true,
   ff_favorites_v2_shared_state: true,
   ff_polymorph_v1: true,
+  ff_combat_state_coalesce_v1: true,
 };
 
 const TRUTHY = new Set(["1", "true", "on", "yes"]);


### PR DESCRIPTION
## Summary

Implementa **R3** do [postmortem de 2026-04-24](../blob/master/docs/postmortem-supabase-cdc-pool-exhaustion-2026-04-24.md) (§Causa #2). A rota `/api/combat/[id]/state` fazia `Promise.all` de 5 queries por polling — 4 delas em dados que mudam ordens-de-magnitude mais devagar que o ciclo de polling (2s), amplificando pressão no pool em 5×.

No incidente: ~155 queries/min concorrendo pelo mesmo pool além da replicação CDC das 13 presences. Essa mudança reduz pra ~30 queries/min (combatants-only) em warm cache.

## TTLs por kind (do §Causa #2)

| Query | Key | TTL | Justificativa |
|---|---|---|---|
| token check | \`tok:{sessionId}:{userId}\` | **15s** | Ownership não muda entre polls salvo revocação |
| session metadata | \`ses:{sessionId}\` | 10s | \`dm_last_seen_at\` bate a cada ~20s |
| active encounter | \`enc:{sessionId}\` | 5s | Round/turn avançam em segundos-a-minutos |
| token owner | \`own:{sessionId}:{tokenIdParam}\` | 60s | Só relevante com \`token_id\` query param |
| lobby tokens | \`lob:{sessionId}\` | 5s | Lista de nomes do lobby |
| **combatants** | — | **UNCACHED** | Hot path — HP/conditions/is_defeated |

## Trade-off do token cache (15s)

Uma revocação explícita (DM setando \`session_tokens.is_active = false\`) tem até **15s de "ghost access"**. Evidência:

- Não existe fluxo ativo de revocação no código (grep confirma — só \`last_seen_at = null\` via disconnect)
- Postmortem não registra revocação como parte do incidente
- Quando/se um fluxo de revocação for adicionado: chame \`invalidate(\"tok:{sessionId}:{userId}\")\` do novo módulo \`lib/cache/request-coalesce\` pra busto explícito

## Feature flag

\`\`\`
ff_combat_state_coalesce_v1  (default TRUE em prod)
\`\`\`

Reversível via env var no Vercel **sem redeploy**: \`NEXT_PUBLIC_FF_COMBAT_STATE_COALESCE_V1=false\`.

## Primitivas novas

**\`lib/cache/request-coalesce.ts\`** — cache in-memory single-flight-lite com:

- \`coalesce(key, ttlMs, producer)\` — cache hit ou miss
- \`invalidate(key)\` — bust explícito pra um key
- \`invalidatePrefix(prefix)\` — bust pra todos keys que começam com prefix
- Bounded at 1000 entries; sweep expired em overflow

Single-process (cada instância serverless tem seu próprio cache). Goal é **pressure reduction**, não strict consistency.

## Test plan

- [x] \`lib/cache/request-coalesce.test.ts\`: **5 cases passing** (hit/miss/TTL/invalidate/prefix/reject)
- [x] \`tsc --noEmit\` limpo
- [ ] Preview env: medir \`scripts/pool-health.mjs\` delta pré/pós merge
- [ ] Watch: \`conversion:cta_shown\` e \`combat:state:*\` counts estáveis

## Riscos conhecidos

1. **Cold-miss storm pós-deploy**: cada instância nova sobe com cache vazio. Não é cumulativo — cada request que popular leva ~200-400ms extra, depois normaliza.
2. **Inconsistência entre instâncias serverless** durante transições (deploy, scale-up): visão do player pode variar por ±TTL até cada instância popular. Aceitável pelos TTLs escolhidos.

## Follow-ups

- R7 do postmortem (split hot/cold endpoints) — deferido conforme decisão do Dani
- Se revocação de token for implementada: adicionar \`invalidate(\`tok:\${sessionId}:\${userId}\`)\` no handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)