### PR TITLE
feat(observability): identity-accumulation probe via Vercel Cron

### DIFF
--- a/app/api/cron/probe-identity/route.ts
+++ b/app/api/cron/probe-identity/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
+import { captureError } from "@/lib/errors/capture";
+
+/**
+ * Vercel Cron — postmortem 2026-04-24 observability.
+ *
+ * Runs daily at 09:00 UTC (06:00 BRT). Invokes the Supabase function
+ * `probe_identity_accumulation()` (migration 183) which counts anon users
+ * and session_tokens, writes an info-level audit row to `error_logs`, and
+ * returns the counts.
+ *
+ * First 21 days: log-only (no threshold). This builds a baseline series.
+ * After baseline, add a threshold-based Slack alert by comparing today's
+ * row to the 7-day median via SQL — the probe itself doesn't change.
+ *
+ * Auth: `Bearer ${CRON_SECRET}` (same pattern as sibling cron routes).
+ */
+export async function GET(req: NextRequest) {
+  const authHeader = req.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = createServiceClient();
+
+  try {
+    const { data, error } = await supabase.rpc("probe_identity_accumulation");
+
+    if (error) {
+      captureError(error, {
+        component: "ProbeIdentityAccumulationCron",
+        action: "rpc",
+        category: "database",
+      });
+      return NextResponse.json({ error: "RPC failed" }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      counts: data,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    captureError(err, {
+      component: "ProbeIdentityAccumulationCron",
+      action: "handler",
+      category: "database",
+    });
+    return NextResponse.json({ error: "Probe failed" }, { status: 500 });
+  }
+}

--- a/app/api/cron/probe-identity/route.ts
+++ b/app/api/cron/probe-identity/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
 
     if (error) {
       captureError(error, {
-        component: "ProbeIdentityAccumulationCron",
+        component: "probe_identity_accumulation",
         action: "rpc",
         category: "database",
       });
@@ -43,7 +43,7 @@ export async function GET(req: NextRequest) {
     });
   } catch (err) {
     captureError(err, {
-      component: "ProbeIdentityAccumulationCron",
+      component: "probe_identity_accumulation",
       action: "handler",
       category: "database",
     });

--- a/scripts/probe-identity-accumulation.mjs
+++ b/scripts/probe-identity-accumulation.mjs
@@ -1,0 +1,86 @@
+// Manual dry-run of the identity-accumulation probe.
+//
+// Mirrors the daily Vercel Cron at /api/cron/probe-identity, but for local
+// use during baseline analysis. Outputs current counts + the last 7 probe
+// rows from error_logs so you can eyeball the growth curve before deciding
+// on a Slack-alert threshold.
+//
+// Usage: node scripts/probe-identity-accumulation.mjs
+// Requires .env.local with NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY.
+
+import { createClient } from "@supabase/supabase-js";
+import fs from "fs";
+
+const env = Object.fromEntries(
+  fs.readFileSync(".env.local", "utf8")
+    .split("\n")
+    .filter((l) => l.trim() && !l.startsWith("#"))
+    .map((l) => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i).trim(), l.slice(i + 1).trim().replace(/^["']|["']$/g, "")];
+    })
+);
+
+const sb = createClient(
+  env.NEXT_PUBLIC_SUPABASE_URL,
+  env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+async function main() {
+  console.log("=== Probe: identity accumulation ===\n");
+
+  const t0 = Date.now();
+  const { data: probe, error: probeErr } = await sb.rpc("probe_identity_accumulation");
+
+  if (probeErr) {
+    console.error("RPC failed:", probeErr);
+    process.exit(1);
+  }
+
+  console.log(`Probed in ${Date.now() - t0}ms:`);
+  console.log(JSON.stringify(probe, null, 2));
+
+  console.log("\n=== Last 7 probe runs (from error_logs) ===\n");
+  const { data: history, error: histErr } = await sb
+    .from("error_logs")
+    .select("created_at, metadata")
+    .eq("component", "probe_identity_accumulation")
+    .order("created_at", { ascending: false })
+    .limit(7);
+
+  if (histErr) {
+    console.error("history query failed:", histErr);
+    process.exit(1);
+  }
+
+  if (!history?.length) {
+    console.log("(no prior runs — this was the first)");
+    return;
+  }
+
+  console.log(
+    ["probed_at", "anon_users", "tokens_total", "tokens_active", "stale_candidates"]
+      .map((h) => h.padStart(20))
+      .join("  ")
+  );
+  for (const row of history) {
+    const m = row.metadata ?? {};
+    console.log(
+      [
+        row.created_at,
+        String(m.anon_user_count ?? "-"),
+        String(m.session_tokens_total ?? "-"),
+        String(m.session_tokens_active ?? "-"),
+        String(m.session_tokens_stale_candidates ?? "-"),
+      ]
+        .map((v) => String(v).padStart(20))
+        .join("  ")
+    );
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/supabase/migrations/183_probe_identity_accumulation.sql
+++ b/supabase/migrations/183_probe_identity_accumulation.sql
@@ -1,0 +1,77 @@
+-- 183_probe_identity_accumulation.sql
+-- Postmortem 2026-04-24 — observability probe pros vetores de crescimento
+-- que o bug de isAnonPlayer (fix #43) estava acelerando silenciosamente.
+--
+-- Context: cada /join/[token] chama signInAnonymously() que cria uma row
+-- em auth.users. Com CTA de conversão quebrado entre 2026-04-20 e
+-- 2026-04-24, zero jogadores anon viraram auth real — toda entrada de
+-- beta tester é uma row nova cumulativa. session_tokens idem (uma por
+-- token/claim). Essa função serve de probe diário pra baselinar o
+-- crescimento e detectar se o fix do PR #43 + cleanup do PR #45 estão
+-- contendo o vetor.
+--
+-- NÃO alerta — só loga em error_logs pra criar série histórica. A
+-- decisão de threshold fica pra daqui 21 dias depois que temos baseline.
+
+CREATE OR REPLACE FUNCTION public.probe_identity_accumulation()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+  anon_user_count integer;
+  session_tokens_total integer;
+  session_tokens_stale_candidates integer;
+  session_tokens_active integer;
+  result jsonb;
+BEGIN
+  -- auth.users é acessível por SECURITY DEFINER (função roda como owner).
+  SELECT count(*) INTO anon_user_count FROM auth.users WHERE is_anonymous = true;
+
+  SELECT count(*) INTO session_tokens_total FROM public.session_tokens;
+
+  SELECT count(*) INTO session_tokens_active
+  FROM public.session_tokens WHERE is_active = true;
+
+  -- Candidatos pro sweep do migration 182. Ajudar a validar se o sweep
+  -- está efetivamente limpando após ligar.
+  SELECT count(*) INTO session_tokens_stale_candidates
+  FROM public.session_tokens
+  WHERE is_active = false
+    AND last_seen_at IS NOT NULL
+    AND last_seen_at < now() - interval '21 days';
+
+  result := jsonb_build_object(
+    'anon_user_count', anon_user_count,
+    'session_tokens_total', session_tokens_total,
+    'session_tokens_active', session_tokens_active,
+    'session_tokens_stale_candidates', session_tokens_stale_candidates,
+    'probed_at', now()
+  );
+
+  -- Audit row — cria série histórica consultável por admin dashboard.
+  INSERT INTO public.error_logs (level, message, component, action, category, metadata)
+  VALUES (
+    'info',
+    format(
+      'identity probe: anon_users=%s, session_tokens_total=%s, stale_candidates=%s',
+      anon_user_count,
+      session_tokens_total,
+      session_tokens_stale_candidates
+    ),
+    'probe_identity_accumulation',
+    'probe',
+    'database',
+    result
+  );
+
+  RETURN result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.probe_identity_accumulation() IS
+  'Postmortem 2026-04-24 — daily identity-accumulation probe. Counts anon auth.users + session_tokens, writes audit row to error_logs, returns jsonb. Read-only; safe to run manually.';
+
+REVOKE ALL ON FUNCTION public.probe_identity_accumulation() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.probe_identity_accumulation() TO service_role;

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/sweep-session-tokens",
       "schedule": "30 4 * * *"
+    },
+    {
+      "path": "/api/cron/probe-identity",
+      "schedule": "0 9 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Baselina o vetor de crescimento que o bug do `isAnonPlayer` ([PR #43](https://github.com/danielroscoe-97/projeto-rpg/pull/43)) estava acelerando silenciosamente. Roda diariamente e escreve audit row em `error_logs` — cria série histórica pra detectar se os fixes estão contendo o vetor, e pra estabelecer threshold de alerta depois de 21 dias de baseline.

## Counts coletados diariamente

| Métrica | Significado |
|---|---|
| `anon_user_count` | `auth.users` WHERE `is_anonymous = true` |
| `session_tokens_total` | cardinalidade total |
| `session_tokens_active` | footprint ativo |
| `session_tokens_stale_candidates` | candidatos pro sweep do [PR #45](https://github.com/danielroscoe-97/projeto-rpg/pull/45) |

## Arquitetura

- **`supabase/migrations/183_probe_identity_accumulation.sql`** — Função SECURITY DEFINER, read-only, `search_path = public, auth`
- **`app/api/cron/probe-identity/route.ts`** — Vercel Cron shim via RPC, `Bearer CRON_SECRET`
- **`scripts/probe-identity-accumulation.mjs`** — Dry-run manual
- **`vercel.json`** — Cron `0 9 * * *` daily

## Review follow-ups aplicados

- **Nit #1** (component name alignment): failed runs agora ficam na mesma série histórica que successes

## Alert policy

Log-only por 21 dias (decisão do Dani). Depois define threshold baseado no P95 da série.

🤖 Generated with [Claude Code](https://claude.com/claude-code)