### PR TITLE
feat(grimório): A3 Perícias 3-col grid desktop (EP-1)

### DIFF
--- a/components/player-hq/ProficienciesSection.tsx
+++ b/components/player-hq/ProficienciesSection.tsx
@@ -67,6 +67,9 @@ function ProfDot({ level }: { level: SkillProficiency | undefined }) {
 }
 
 // ── Saving throw row ──────────────────────────────────────────────
+// Dense row used inside a grid (1-col mobile, 3-col desktop ≥1024px).
+// Target height ≤36px per 08-design-tokens-delta.md §2.4. Typography
+// follows §3.1 (`text-[13px]`, tabular-nums, caps tracking 0.08em).
 function SaveRow({
   ability,
   label,
@@ -86,20 +89,24 @@ function SaveRow({
 }) {
   const total = mod + (isProficient ? profBonus : 0);
   return (
-    <div className="flex items-center gap-2 py-1">
+    <div
+      data-testid={`save-row-${ability}`}
+      className="flex items-center gap-2 py-1.5 min-h-[32px]"
+    >
       {editing ? (
         <button
           type="button"
           onClick={onToggle}
-          className="w-4 h-4 rounded-full border border-white/20 flex items-center justify-center hover:border-gold/50 transition-colors"
+          className="w-4 h-4 rounded-full border border-white/20 flex items-center justify-center hover:border-gold/50 transition-colors shrink-0"
+          aria-label={label}
         >
           {isProficient && <div className="w-2.5 h-2.5 rounded-full bg-gold" />}
         </button>
       ) : (
         <ProfDot level={isProficient ? "proficient" : undefined} />
       )}
-      <span className="text-sm text-foreground flex-1">{label}</span>
-      <span className={`text-sm font-mono font-semibold ${isProficient ? "text-gold" : "text-muted-foreground"}`}>
+      <span className="text-[13px] leading-[18px] text-foreground flex-1 truncate">{label}</span>
+      <span className={`text-[13px] font-mono font-semibold tabular-nums min-w-[28px] text-right ${isProficient ? "text-gold" : "text-muted-foreground"}`}>
         {formatMod(total)}
       </span>
     </div>
@@ -107,6 +114,8 @@ function SaveRow({
 }
 
 // ── Skill row ─────────────────────────────────────────────────────
+// Dense row used inside a 3-col grid on desktop (1-col on mobile).
+// Target height ≤36px per 08-design-tokens-delta.md §2.4.
 function SkillRow({
   skill,
   label,
@@ -130,13 +139,17 @@ function SkillRow({
   const total = mod + bonus;
 
   return (
-    <div className="flex items-center gap-2 py-1">
+    <div
+      data-testid={`skill-row-${skill}`}
+      className="flex items-center gap-2 py-1.5 min-h-[32px]"
+    >
       {editing ? (
         <button
           type="button"
           onClick={onCycle}
-          className="w-4 h-4 rounded-full border border-white/20 flex items-center justify-center hover:border-gold/50 transition-colors"
+          className="w-4 h-4 rounded-full border border-white/20 flex items-center justify-center hover:border-gold/50 transition-colors shrink-0"
           title="Click: none → proficient → expertise → none"
+          aria-label={label}
         >
           {profLevel === "expertise" && <Star className="w-2.5 h-2.5 text-gold" />}
           {profLevel === "proficient" && <div className="w-2.5 h-2.5 rounded-full bg-gold" />}
@@ -144,9 +157,9 @@ function SkillRow({
       ) : (
         <ProfDot level={profLevel} />
       )}
-      <span className="text-sm text-foreground flex-1">{label}</span>
-      <span className="text-[10px] text-muted-foreground/60 uppercase">{abilityLabel}</span>
-      <span className={`text-sm font-mono font-semibold min-w-[28px] text-right ${profLevel ? "text-gold" : "text-muted-foreground"}`}>
+      <span className="text-[13px] leading-[18px] text-foreground flex-1 truncate">{label}</span>
+      <span className="text-[10px] text-muted-foreground/60 uppercase tracking-[0.08em] shrink-0">{abilityLabel}</span>
+      <span className={`text-[13px] font-mono font-semibold tabular-nums min-w-[28px] text-right ${profLevel ? "text-gold" : "text-muted-foreground"}`}>
         {formatMod(total)}
       </span>
     </div>
@@ -348,7 +361,10 @@ export function ProficienciesSection({
             onToggle={() => toggleSection("saves")}
           />
           {openSections.saves !== false && (
-            <div className="pl-2 mt-1">
+            <div
+              data-testid="saves-grid"
+              className="pl-2 mt-1 grid grid-cols-1 lg:grid-cols-3 gap-x-4"
+            >
               {SAVING_THROWS.map((ability) => (
                 <SaveRow
                   key={ability}
@@ -375,7 +391,10 @@ export function ProficienciesSection({
             onToggle={() => toggleSection("skills")}
           />
           {openSections.skills !== false && (
-            <div className="pl-2 mt-1">
+            <div
+              data-testid="skills-grid"
+              className="pl-2 mt-1 grid grid-cols-1 lg:grid-cols-3 gap-x-4"
+            >
               {SKILLS.map(({ key, ability }) => (
                 <SkillRow
                   key={key}


### PR DESCRIPTION
## Resumo

Densifica `ProficienciesSection` aplicando o grid 3-col em desktop (≥1024px) e mantendo single-col em mobile. Tipografia das rows condensada pro padrão denso do redesign (text-[13px]/18px, tabular-nums, min-h 32px).

## Referências

- Wireframe: [_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md §4.4.3](../blob/master/_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md#443-perícias)
- Design tokens: [08-design-tokens-delta.md §2.4 + §3.1 + §5.4](../blob/master/_bmad-output/party-mode-2026-04-22/08-design-tokens-delta.md#54-skill-grid-3-col)
- Implementation plan: [09-implementation-plan.md §A3](../blob/master/_bmad-output/party-mode-2026-04-22/09-implementation-plan.md#a3-densificar-rows-de-perícias)
- Sprint: EP-1 Sprint 2 Track B, closes EP-1 A3

## O que muda

- Saves grid: `flex` → `grid grid-cols-1 lg:grid-cols-3 gap-x-4` (6 saves em 2 rows × 3 cols no desktop)
- Skills grid: mesma transformação (18 skills em 6 rows × 3 cols no desktop)
- Row height target ≤36px via `py-1.5 min-h-[32px]`
- Typography alinhada com §3.1: `text-[13px] leading-[18px]` pro label, `text-[10px] uppercase tracking-[0.08em]` pra ability caps, `tabular-nums` em todo mod
- `data-testid` hooks (`save-row-{ability}`, `skill-row-{skill}`, `saves-grid`, `skills-grid`) pra suportar `sheet-ability-chips-always-visible` + futuros specs do Gate Fase A
- `aria-label` em todos os toggle buttons de edit mode (a11y)

## Checklist

- [x] `rtk tsc --noEmit` passa
- [x] `rtk lint` passa (eslint direto na file — sem regressão)
- [x] Unit tests passam (não há unit test dedicado a este componente ainda; cobertura virá em `sheet-header-density.spec.ts`)
- [x] Combat Parity: **N/A** — mudança visual puramente Auth (`/sheet`). Player HQ não renderiza pra Guest (`/try`) nem pra Anônimo em combate (`/join` usa `PlayerJoinClient`, não `PlayerHqShell`).
- [x] "Mestre" em todos os textos user-facing (nunca "DM") — PR só mexe em layout, nenhum texto novo
- [x] HP tiers N/A — arquivo não toca HP

## Review

**Esta PR muda pixels visíveis pro usuário?**

- [ ] Não — só refactor interno / infra / testes → review Dev + Dani
- [x] Sim — UI/UX afetada → **requer aprovação Sally (UX) + Piper (Mestre-alvo)** antes do merge

Label `ux-review-required` aplicada.

## Test plan

### Desktop 1440
- [ ] Abrir `/sheet` em campanha autenticada
- [ ] Proficiencies card mostra saves em 3 colunas (2 rows) e skills em 3 colunas (6 rows)
- [ ] Totais dos modificadores corretos para STR/DEX/CON/INT/WIS/CHA e todas as 18 skills
- [ ] Click no Edit mode: dots viram botões (3-state cycle mantido para skills)
- [ ] Altura total do card reduzida vs baseline da Sprint 1 (PR #46)

### Mobile 390
- [ ] `/sheet` em viewport 390px
- [ ] Grid vira single-col, nenhuma truncamento inesperado
- [ ] Tap targets dos dots em edit mode seguem funcionando (≥40px combinando com padding do container)

### Regressão
- [ ] Accordions de Tools/Languages/Armor/Weapons inalterados
- [ ] Section toggle (expand/collapse) de Saves e Skills funciona
- [ ] `t("skill_*")` keys intactas — labels i18n corretos em PT-BR e EN