### PR TITLE
feat(grimório): condense Player HQ header to 2 lines with quick resources (EP-1 A4)

### DIFF
--- a/components/player-hq/PlayerHqShell.tsx
+++ b/components/player-hq/PlayerHqShell.tsx
@@ -157,19 +157,25 @@ function PlayerHqQuickResources({
       data-testid="hq-header-quick-resources"
     >
       {/* HD — data not yet modelled on player_characters */}
-      <span className="inline-flex items-baseline gap-1 text-muted-foreground">
-        <span className="text-[11px] uppercase tracking-[0.08em]">
+      <span
+        className="inline-flex items-baseline gap-1 text-muted-foreground"
+        aria-label={t("header.hd_empty_aria")}
+      >
+        <span className="text-[11px] uppercase tracking-[0.08em]" aria-hidden="true">
           {t("header.hd_label")}
         </span>
-        <span>{placeholder}</span>
+        <span aria-hidden="true">{placeholder}</span>
       </span>
       <Sep />
       {/* CD — data not yet modelled (class.resources.primary pending Sprint 3+) */}
-      <span className="inline-flex items-baseline gap-1 text-muted-foreground">
-        <span className="text-[11px] uppercase tracking-[0.08em]">
+      <span
+        className="inline-flex items-baseline gap-1 text-muted-foreground"
+        aria-label={t("header.cd_empty_aria")}
+      >
+        <span className="text-[11px] uppercase tracking-[0.08em]" aria-hidden="true">
           {t("header.cd_label")}
         </span>
-        <span>{placeholder}</span>
+        <span aria-hidden="true">{placeholder}</span>
       </span>
       <Sep />
       {/* Inspiration — muted when zero per §13.1 */}
@@ -183,7 +189,9 @@ function PlayerHqQuickResources({
         </span>
         <span>{inspCount}</span>
       </span>
-      {/* Spell slots chip — click jumps to Resources tab (Sprint 3+: scroll-to + highlight) */}
+      {/* Spell slots chip — click switches to Resources tab (Sprint 3+: the
+          spec §13.2 scroll-to + highlight ring upgrade lands with the V2
+          shell; today we switch tabs as a usable stop-gap). */}
       {hasSlots && (
         <button
           type="button"
@@ -193,7 +201,7 @@ function PlayerHqQuickResources({
             max: slotsMax,
           })}
           data-testid="hq-header-slots-chip"
-          className="inline-flex items-center gap-1 text-[12px] font-medium text-amber-400 hover:text-amber-300 transition-colors min-h-[44px] sm:min-h-[28px] px-1 -mx-1 rounded focus:outline-none focus:ring-2 focus:ring-amber-400/50"
+          className="inline-flex items-center gap-1 basis-full sm:basis-auto justify-end sm:justify-start text-[12px] font-medium text-amber-400 hover:text-amber-300 transition-colors min-h-[44px] sm:min-h-[28px] px-1 -mx-1 rounded focus:outline-none focus:ring-2 focus:ring-amber-400/50"
         >
           <Sparkles className="w-3.5 h-3.5" aria-hidden />
           <span>

--- a/components/player-hq/PlayerHqShell.tsx
+++ b/components/player-hq/PlayerHqShell.tsx
@@ -109,6 +109,106 @@ function TabBar({
   );
 }
 
+/**
+ * Line 2 of the Player HQ header (EP-1 A4 "Recursos rápidos").
+ * Canonical spec: _bmad-output/party-mode-2026-04-22/08-design-tokens-delta.md §13
+ *
+ * Renders `HD x/y · CD x/y · Insp x · [✨ Slots X/Y →]`.
+ *
+ * `hit_dice` and `class.resources.primary` are not yet modelled on
+ * `player_characters` — those chips render the muted em-dash placeholder
+ * until Sprint 3+ lands the schema. Inspiration + spell slot total are live.
+ */
+function PlayerHqQuickResources({
+  inspiration,
+  spellSlots,
+  onJumpToSlots,
+  t,
+}: {
+  inspiration: boolean;
+  spellSlots: Record<string, { max: number; used: number }> | null;
+  onJumpToSlots: () => void;
+  t: ReturnType<typeof useTranslations<"player_hq">>;
+}) {
+  const inspCount = inspiration ? 1 : 0;
+  const inspMuted = inspCount === 0;
+
+  const { slotsUsed, slotsMax } = (() => {
+    if (!spellSlots) return { slotsUsed: 0, slotsMax: 0 };
+    return Object.values(spellSlots).reduce(
+      (acc, s) => ({
+        slotsUsed: acc.slotsUsed + (s?.used ?? 0),
+        slotsMax: acc.slotsMax + (s?.max ?? 0),
+      }),
+      { slotsUsed: 0, slotsMax: 0 }
+    );
+  })();
+
+  const hasSlots = slotsMax > 0;
+  const placeholder = t("header.empty_placeholder");
+  // Separator shared across chips (U+00B7 middle dot).
+  const Sep = () => (
+    <span aria-hidden className="text-muted-foreground/60 select-none">·</span>
+  );
+
+  return (
+    <div
+      className="flex items-center flex-wrap gap-x-3 gap-y-1 pl-8 text-[13px] tabular-nums"
+      data-testid="hq-header-quick-resources"
+    >
+      {/* HD — data not yet modelled on player_characters */}
+      <span className="inline-flex items-baseline gap-1 text-muted-foreground">
+        <span className="text-[11px] uppercase tracking-[0.08em]">
+          {t("header.hd_label")}
+        </span>
+        <span>{placeholder}</span>
+      </span>
+      <Sep />
+      {/* CD — data not yet modelled (class.resources.primary pending Sprint 3+) */}
+      <span className="inline-flex items-baseline gap-1 text-muted-foreground">
+        <span className="text-[11px] uppercase tracking-[0.08em]">
+          {t("header.cd_label")}
+        </span>
+        <span>{placeholder}</span>
+      </span>
+      <Sep />
+      {/* Inspiration — muted when zero per §13.1 */}
+      <span
+        className={`inline-flex items-baseline gap-1 ${
+          inspMuted ? "text-muted-foreground" : "text-foreground"
+        }`}
+      >
+        <span className="text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
+          {t("header.inspiration_short")}
+        </span>
+        <span>{inspCount}</span>
+      </span>
+      {/* Spell slots chip — click jumps to Resources tab (Sprint 3+: scroll-to + highlight) */}
+      {hasSlots && (
+        <button
+          type="button"
+          onClick={onJumpToSlots}
+          aria-label={t("header.slots_chip_aria", {
+            used: slotsUsed,
+            max: slotsMax,
+          })}
+          data-testid="hq-header-slots-chip"
+          className="inline-flex items-center gap-1 text-[12px] font-medium text-amber-400 hover:text-amber-300 transition-colors min-h-[44px] sm:min-h-[28px] px-1 -mx-1 rounded focus:outline-none focus:ring-2 focus:ring-amber-400/50"
+        >
+          <Sparkles className="w-3.5 h-3.5" aria-hidden />
+          <span>
+            {t("header.slots_chip_label", {
+              used: slotsUsed,
+              max: slotsMax,
+            })}
+          </span>
+          <span aria-hidden>→</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
 interface PlayerHqShellProps {
   characterId: string;
   campaignId: string;
@@ -172,61 +272,80 @@ export function PlayerHqShell({
       {/* Player HQ Tour — triggers on first visit */}
       <PlayerHqTourProvider shouldAutoStart={!playerHqTourCompleted} />
 
-      {/* Header */}
-      <div className="flex items-center gap-3" data-tour-id="hq-header">
-        <Link
-          href={`/app/campaigns/${campaignId}`}
-          className="text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <ChevronLeft className="w-5 h-5" />
-        </Link>
-        <div className="min-w-0 flex-1">
-          <h1 className="text-lg font-semibold text-foreground truncate flex items-center gap-1.5">
-            <ClassIcon characterClass={character.class} size={20} className="text-amber-400 flex-shrink-0" />
-            {character.name}
-          </h1>
-          <p className="text-xs text-muted-foreground truncate">
-            {[character.race, character.class, character.level ? `${t("sheet.level_prefix")}${character.level}` : null]
-              .filter(Boolean)
-              .join(" · ") || campaignName}
-          </p>
+      {/* Header — 2 lines: (1) identity, (2) recursos rápidos */}
+      <div className="flex flex-col gap-1.5" data-tour-id="hq-header">
+        {/* Line 1: identity row */}
+        <div className="flex items-center gap-3 min-w-0">
+          <Link
+            href={`/app/campaigns/${campaignId}`}
+            aria-label={t("header.back_aria")}
+            className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </Link>
+          <div className="min-w-0 flex-1 flex items-center gap-1.5">
+            <ClassIcon
+              characterClass={character.class}
+              size={20}
+              className="text-amber-400 flex-shrink-0"
+            />
+            <h1 className="text-lg font-semibold text-foreground truncate">
+              {[
+                campaignName,
+                character.name,
+                [character.race, character.class].filter(Boolean).join("/") || null,
+                character.level
+                  ? `${t("sheet.level_prefix")}${character.level}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </h1>
+          </div>
+          <CharacterPdfExport
+            character={{
+              ...character,
+              proficiencies: character.proficiencies ?? {},
+            }}
+          />
+          <CharacterEditSheet
+            character={character}
+            onSave={saveField}
+            translations={{
+              edit_character: t("edit.edit_character"),
+              identity: t("edit.identity"),
+              combat_stats: t("edit.combat_stats"),
+              attributes: t("edit.attributes"),
+              notes: t("edit.notes"),
+              name: t("edit.name"),
+              race: t("edit.race"),
+              class: t("edit.class"),
+              level: t("edit.level"),
+              subclass: t("edit.subclass"),
+              subrace: t("edit.subrace"),
+              background: t("edit.background"),
+              alignment: t("edit.alignment"),
+              max_hp: t("edit.max_hp"),
+              ac: t("edit.ac"),
+              speed: t("edit.speed"),
+              initiative_bonus: t("edit.initiative_bonus"),
+              spell_save_dc: t("edit.spell_save_dc"),
+              str: t("edit.str"),
+              dex: t("edit.dex"),
+              con: t("edit.con"),
+              int: t("edit.int"),
+              wis: t("edit.wis"),
+              cha: t("edit.cha"),
+              notes_placeholder: t("edit.notes_placeholder"),
+            }}
+          />
         </div>
-        <CharacterPdfExport
-          character={{
-            ...character,
-            proficiencies: character.proficiencies ?? {},
-          }}
-        />
-        <CharacterEditSheet
-          character={character}
-          onSave={saveField}
-          translations={{
-            edit_character: t("edit.edit_character"),
-            identity: t("edit.identity"),
-            combat_stats: t("edit.combat_stats"),
-            attributes: t("edit.attributes"),
-            notes: t("edit.notes"),
-            name: t("edit.name"),
-            race: t("edit.race"),
-            class: t("edit.class"),
-            level: t("edit.level"),
-            subclass: t("edit.subclass"),
-            subrace: t("edit.subrace"),
-            background: t("edit.background"),
-            alignment: t("edit.alignment"),
-            max_hp: t("edit.max_hp"),
-            ac: t("edit.ac"),
-            speed: t("edit.speed"),
-            initiative_bonus: t("edit.initiative_bonus"),
-            spell_save_dc: t("edit.spell_save_dc"),
-            str: t("edit.str"),
-            dex: t("edit.dex"),
-            con: t("edit.con"),
-            int: t("edit.int"),
-            wis: t("edit.wis"),
-            cha: t("edit.cha"),
-            notes_placeholder: t("edit.notes_placeholder"),
-          }}
+        {/* Line 2: recursos rápidos (HD · CD · Insp · Slots chip) */}
+        <PlayerHqQuickResources
+          inspiration={character.inspiration}
+          spellSlots={character.spell_slots}
+          onJumpToSlots={() => setActiveTab("resources")}
+          t={t}
         />
       </div>
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -1149,6 +1149,15 @@
       "abilities": "Abilities",
       "aria_tablist": "Character tabs"
     },
+    "header": {
+      "back_aria": "Back to campaign",
+      "hd_label": "HD",
+      "cd_label": "CD",
+      "inspiration_short": "Insp",
+      "slots_chip_label": "Slots {used}/{max}",
+      "slots_chip_aria": "Spell slots: {used} used out of {max}. Click to see details.",
+      "empty_placeholder": "—"
+    },
     "npc_drawer": {
       "relationship": "Relationship",
       "rel_ally": "Ally",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1155,8 +1155,10 @@
       "cd_label": "CD",
       "inspiration_short": "Insp",
       "slots_chip_label": "Slots {used}/{max}",
-      "slots_chip_aria": "Spell slots: {used} used out of {max}. Click to see details.",
-      "empty_placeholder": "—"
+      "slots_chip_aria": "Spell slots: {used} used out of {max}. Click to switch to the Resources tab.",
+      "empty_placeholder": "—",
+      "hd_empty_aria": "Hit Dice tracking coming soon",
+      "cd_empty_aria": "Class resources tracking coming soon"
     },
     "npc_drawer": {
       "relationship": "Relationship",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1149,6 +1149,15 @@
       "abilities": "Habilidades",
       "aria_tablist": "Abas do personagem"
     },
+    "header": {
+      "back_aria": "Voltar para a campanha",
+      "hd_label": "HD",
+      "cd_label": "CD",
+      "inspiration_short": "Insp",
+      "slots_chip_label": "Slots {used}/{max}",
+      "slots_chip_aria": "Espaços de magia: {used} usados de {max}. Clique para ver detalhes.",
+      "empty_placeholder": "—"
+    },
     "npc_drawer": {
       "relationship": "Relação",
       "rel_ally": "Aliado",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1155,8 +1155,10 @@
       "cd_label": "CD",
       "inspiration_short": "Insp",
       "slots_chip_label": "Slots {used}/{max}",
-      "slots_chip_aria": "Espaços de magia: {used} usados de {max}. Clique para ver detalhes.",
-      "empty_placeholder": "—"
+      "slots_chip_aria": "Espaços de magia: {used} usados de {max}. Clique para ir para a aba Recursos.",
+      "empty_placeholder": "—",
+      "hd_empty_aria": "Rastreamento de Hit Dice em breve",
+      "cd_empty_aria": "Rastreamento de recursos de classe em breve"
     },
     "npc_drawer": {
       "relationship": "Relação",


### PR DESCRIPTION
## Resumo

Colapsa o header do Player HQ de 4 linhas visuais pra 2, seguindo o canônico §13 de `08-design-tokens-delta.md`:

- **Linha 1:** `◄ Campanha · Nome · Raça/Classe · Nv N` + `[PDF][✎]` à direita
- **Linha 2:** chip row de recursos rápidos — `HD —/— · CD —/— · Insp X · [✨ Slots X/Y →]`

O chip `[✨ Slots X/Y →]` abre a tab Recursos on click (em Sprint 3+ vira scroll-to-section + highlight ring por §13.2). Tap target `min-h-[44px]` mobile / `min-h-[28px]` desktop — mesmo pattern canônico do `CombatantRow.tsx:540-587`.

`HD` e `CD` renderizam em muted com em-dash placeholder até o schema ganhar `hit_dice` + `class.resources.primary` (Sprint 3+). Inspiração + total de spell slots vêm de campos que já existem (`inspiration` bool, `spell_slots` map).

> **Base branch:** este PR empilha em `feat/ep-1-a1-density-tokens` (PR #49, A1). Após A1 mergear, rebase + retarget pra master.

## Referências

- Wireframe: [_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md](../_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md) §4.1 HEADER
- Canônico linha 2: [_bmad-output/party-mode-2026-04-22/08-design-tokens-delta.md](../_bmad-output/party-mode-2026-04-22/08-design-tokens-delta.md) §13 (Recursos rápidos)
- Plano: [09-implementation-plan.md](../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md) §A4
- Decisão PRD: Sprint 2 kickoff 2026-04-23 (UX calibrada com Sally + Piper)
- Sprint: Sprint 2 Track A · Wave 1 · closes EP-1 A4

## Checklist

- [x] `rtk tsc --noEmit` passa
- [x] `rtk lint` passa (sem regressão)
- [x] Unit tests passam (N/A — sem suites diretas; E2E `sheet-header-density.spec.ts` é Track B)
- [x] "Mestre" em todos os textos user-facing (N/A — sem referência a Mestre aqui)
- [x] HP tiers em EN (N/A — não toca HP)

## Combat Parity

**N/A** — density visual pura na ficha (`/sheet`). O chip Slots é Auth-only (Guest/Anon não têm spell_slots persisted). GuestCombatClient e PlayerJoinClient não afetados.

## Review

**Esta PR muda pixels visíveis pro usuário?**

- [x] Sim — UI/UX afetada → **requer aprovação Sally (UX) + Piper (Mestre-alvo)** antes do merge

Label `ux-review-required` marcada.

## Test plan

### Visual manual
1. Abrir `/app/campaigns/[id]/sheet` em desktop 1440px — header deve ter exatamente 2 linhas
2. Linha 1: chevron + campanha · nome · raça/classe · Nv X + PDF + Edit (tudo em uma linha, truncate se estourar)
3. Linha 2 visível abaixo com HD —/— · CD —/— · Insp 0 · (chip aparece só se `spell_slots` tem algum level com max>0)
4. Personagem caster (tem spell slots): chip `[✨ Slots X/Y →]` aparece — click abre tab "Recursos"
5. Personagem não-caster: chip Slots omitido
6. Toggle inspiração: contador atualiza (0 muted → 1 foreground)
7. Mobile 390px: linha 2 pode wrap (chips flex-wrap) — preservar ordem, chip gold mantém tap target 44px

### Regressão
- Header fica ≤56px em desktop (AC A4); mobile pode crescer levemente se wrappar (aceitável per §13.4)
- PDF export + Edit sheet abrem normalmente
- Link chevron navega pra `/app/campaigns/[id]`
- Tabs continuam renderizando tab default "map" (inalterado nesta PR)

### Dados faltantes (documentado)
- `hit_dice` não existe em `player_characters` hoje → HD renderiza `—/—` muted (spec §13.1)
- `class.resources.primary` também não modelado → CD renderiza `—/—` muted
- Sprint 3+ adiciona schema + migra chips pra usar dados reais

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)