### PR TITLE
feat(grimório): kill ability scores accordion, keep chips always visible (EP-1 A2)

### DIFF
--- a/components/player-hq/CharacterCoreStats.tsx
+++ b/components/player-hq/CharacterCoreStats.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import { Shield, Zap, Footprints, Sparkles, ChevronDown, ChevronUp } from "lucide-react";
+import { Shield, Zap, Footprints, Sparkles } from "lucide-react";
 const ABILITY_SCORES = [
   { key: "str", label: "STR" },
   { key: "dex", label: "DEX" },
@@ -50,7 +49,6 @@ export function CharacterCoreStats({
   onToggleInspiration,
 }: CharacterCoreStatsProps) {
   const t = useTranslations("player_hq.sheet");
-  const [showAttributes, setShowAttributes] = useState(false);
 
   const abilityValues: Record<AbilityKey, number | null> = {
     str,
@@ -127,44 +125,38 @@ export function CharacterCoreStats({
         </div>
       )}
 
-      {/* Ability Scores (accordion) */}
+      {/* Ability Scores — always visible (EP-1 A2: accordion killed per 09-implementation-plan.md §A2) */}
       {hasAnyAbility && (
-        <div className="bg-card border border-border rounded-xl overflow-hidden">
-          <button
-            type="button"
-            onClick={() => setShowAttributes((v) => !v)}
-            className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <span>{t("attributes_label")}</span>
-            {showAttributes ? (
-              <ChevronUp className="w-4 h-4" />
-            ) : (
-              <ChevronDown className="w-4 h-4" />
-            )}
-          </button>
-          {showAttributes && (
-            <div className="grid grid-cols-3 gap-2 px-4 pb-4">
-              {ABILITY_SCORES.map(({ key, label }) => {
-                const score = abilityValues[key];
-                return (
-                  <div
-                    key={key}
-                    className="bg-background/50 border border-border rounded-lg p-2 text-center"
-                  >
-                    <p className="text-[10px] text-muted-foreground uppercase tracking-wider">
-                      {label}
-                    </p>
-                    <p className="text-xl font-bold text-foreground tabular-nums">
-                      {getModifier(score)}
-                    </p>
-                    <p className="text-[10px] text-muted-foreground tabular-nums">
-                      {score ?? "—"}
-                    </p>
-                  </div>
-                );
-              })}
-            </div>
-          )}
+        <div
+          className="bg-card border border-border rounded-xl px-4 py-3"
+          role="group"
+          aria-label={t("attributes_label")}
+        >
+          <p className="text-[10px] text-muted-foreground uppercase tracking-wider mb-2">
+            {t("attributes_label")}
+          </p>
+          <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
+            {ABILITY_SCORES.map(({ key, label }) => {
+              const score = abilityValues[key];
+              return (
+                <div
+                  key={key}
+                  className="bg-background/50 border border-border rounded-lg p-2 text-center"
+                  data-testid={`ability-chip-${key}`}
+                >
+                  <p className="text-[10px] text-muted-foreground uppercase tracking-wider">
+                    {label}
+                  </p>
+                  <p className="text-xl font-bold text-foreground tabular-nums">
+                    {getModifier(score)}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground tabular-nums">
+                    {score ?? "—"}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Resumo

Remove o toggle `[Attributes ▾]` que escondia os chips STR/DEX/CON/INT/WIS/CHA atrás de um clique extra. Por `wireframe-heroi.md §4.4.1` os chips devem ser permanentemente expostos — zero clique pra ver modifier é o AC canônico da A2.

## Referências

- Wireframe: [_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md](../_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md) §4.4.1 + §3 (mobile 3×2)
- Plano: [09-implementation-plan.md](../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md) §A2 (AC: "Zero clique pra ver modifier")
- Tokens: [08-design-tokens-delta.md](../_bmad-output/party-mode-2026-04-22/08-design-tokens-delta.md) §2.3 (chip ≤72px)
- E2E: Track B vai autorar `sheet-ability-chips-always-visible.spec.ts` usando os novos `data-testid` anchors
- Sprint: Sprint 2 Track A · Wave 1 · closes EP-1 A2

## Checklist

- [x] `rtk tsc --noEmit` passa
- [x] `rtk lint` passa (sem regressão)
- [x] Unit tests passam (N/A — sem suites; Track B adiciona E2E)
- [x] "Mestre" em todos os textos user-facing (N/A — sem UI copy)
- [x] HP tiers em EN (N/A — não toca HP)

## Combat Parity

**N/A** — density puramente visual em `/sheet` (Auth-only). Ability scores são Auth-only por design (Guest/Anon não têm ficha persistida com STR/DEX/CON...).

## Review

**Esta PR muda pixels visíveis pro usuário?**

- [x] Sim — UI/UX afetada → **requer aprovação Sally (UX) + Piper (Mestre-alvo)** antes do merge

Label `ux-review-required` marcada.

## Test plan

### Visual manual
1. `/app/campaigns/[id]/sheet?tab=sheet` desktop 1440px — 6 chips (STR/DEX/CON/INT/WIS/CHA) sempre visíveis em uma linha
2. Mobile 390px — mesmo 6 chips em layout 3×2 (3 colunas, 2 linhas)
3. Personagem com atributos em branco (null): chip mostra "—" / "—" — comportamento inalterado vs hoje
4. Personagem com ability scores parciais (só STR preenchido por ex): card inteiro aparece, modifiers calculados; os vazios mostram "—"
5. Toggle/accordion `[Attributes ▾]` **não existe mais** — zero clique pra ver modifier

### Regressão
- AC / INIT / SPEED / INSPIRATION cards (linha acima) inalterados
- Spell Save DC badge (quando presente) inalterada
- `onToggleInspiration` callback intacto
- Unused imports `ChevronDown`/`ChevronUp`/`useState`/`useCallback` removidos (build não regride)

### A11y
- Chips agora têm `role="group"` + `aria-label={t("attributes_label")}` — região semanticamente agrupada
- `data-testid="ability-chip-{key}"` em cada chip (anchors estáveis pra E2E suite)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)