### PR TITLE
feat(schema): A4 hit_dice + class_resources on player_characters (184)

### DIFF
--- a/app/app/(with-sidebar)/combat/new/page.tsx
+++ b/app/app/(with-sidebar)/combat/new/page.tsx
@@ -254,6 +254,11 @@ function NewEncounterPageInner() {
         traits: null,
         proficiencies: {},
         currency: { cp: 0, sp: 0, ep: 0, gp: 0, pp: 0 },
+        // Migration 184 — header-optimized trackers. Placeholder rows start
+        // empty; real data hydrates from player_characters when the player
+        // joins for real. A4 header shows em-dash for {max:0,used:0}/{}.
+        hit_dice: { max: 0, used: 0 },
+        class_resources: {},
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       } as PlayerCharacter));

--- a/lib/types/database.ts
+++ b/lib/types/database.ts
@@ -144,6 +144,13 @@ export interface Database {
           traits: { personality?: string; ideal?: string; bond?: string; flaw?: string } | null;
           proficiencies: CharacterProficiencies;
           currency: { cp: number; sp: number; ep: number; gp: number; pp: number };
+          /** Migration 184 — Hit Dice tracker. `{max:0,used:0}` means data not yet tracked (A4 header renders em-dash). */
+          hit_dice: { max: number; used: number };
+          /** Migration 184 — class-specific primary resources. Canonical shape `{primary:{name,max,used}}`; empty `{}` means data not yet tracked. */
+          class_resources: {
+            primary?: { name: string; max: number; used: number };
+            [key: string]: unknown;
+          };
           created_at: string;
           updated_at: string;
         };
@@ -182,6 +189,11 @@ export interface Database {
           proficiencies?: CharacterProficiencies;
           traits?: { personality?: string; ideal?: string; bond?: string; flaw?: string } | null;
           currency?: { cp: number; sp: number; ep: number; gp: number; pp: number };
+          hit_dice?: { max: number; used: number };
+          class_resources?: {
+            primary?: { name: string; max: number; used: number };
+            [key: string]: unknown;
+          };
           created_at?: string;
           updated_at?: string;
         };
@@ -219,6 +231,11 @@ export interface Database {
           proficiencies?: CharacterProficiencies;
           traits?: { personality?: string; ideal?: string; bond?: string; flaw?: string } | null;
           currency?: { cp: number; sp: number; ep: number; gp: number; pp: number };
+          hit_dice?: { max: number; used: number };
+          class_resources?: {
+            primary?: { name: string; max: number; used: number };
+            [key: string]: unknown;
+          };
           updated_at?: string;
         };
       };

--- a/supabase/migrations/184_player_characters_hit_dice_class_resources.sql
+++ b/supabase/migrations/184_player_characters_hit_dice_class_resources.sql
@@ -1,0 +1,46 @@
+-- 184_player_characters_hit_dice_class_resources.sql
+--
+-- Adds two JSONB columns to `player_characters` so the A4 Player HQ
+-- header can render real data instead of em-dash placeholders.
+--
+-- Why JSONB instead of separate numeric columns:
+--   - `hit_dice` is a 2-field struct ({max, used}); keeping it bundled
+--     mirrors the existing `spell_slots` pattern (line 137 of database.ts:
+--     `spell_slots: Record<string, { max: number; used: number }>`).
+--   - `class_resources` needs to be flexible across classes: Channel
+--     Divinity (Cleric, 1-3/long), Ki (Monk, N/short), Sorcery Points
+--     (Sorcerer, N/long), Rages (Barbarian, N/long), etc. Some classes
+--     have multiple primary resources (e.g. Warlock: pact slots + two
+--     Invocations bonus). JSONB future-proofs without schema churn.
+--
+-- Both columns get NOT NULL + default empty struct so existing rows get
+-- safe values without app code having to handle null explicitly.
+--
+-- Backfill: a follow-up app-level job can derive `hit_dice.max = level`
+-- for existing characters once classes know their hit-die size. For now
+-- the defaults render as "HD —" / "CD —" which matches the A4 PR's
+-- current em-dash placeholder behavior (Spec 13.1 "x=0 muta label pra
+-- muted" extended to "data missing").
+
+BEGIN;
+
+ALTER TABLE player_characters
+  ADD COLUMN IF NOT EXISTS hit_dice JSONB NOT NULL DEFAULT '{"max": 0, "used": 0}'::jsonb,
+  ADD COLUMN IF NOT EXISTS class_resources JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN player_characters.hit_dice IS
+  'Hit Dice tracker — JSONB {max: number, used: number}. Max usually = character level; used increments when player burns a die on a short rest and decrements on long rest. Default {0,0} means data not yet tracked (A4 header shows em-dash).';
+
+COMMENT ON COLUMN player_characters.class_resources IS
+  'Class-specific primary resources — JSONB. Canonical shape: {primary: {name: string, max: number, used: number}, ...}. Flexible to support multi-resource classes. Default {} means data not yet tracked (A4 header shows em-dash).';
+
+-- Optional soundness check: ensure hit_dice payload keeps its shape.
+-- (Not a hard constraint — app code is the source of truth for JSON shape;
+-- check keeps grossly malformed rows out, doesn't enforce key presence.)
+ALTER TABLE player_characters
+  ADD CONSTRAINT player_characters_hit_dice_is_object
+    CHECK (jsonb_typeof(hit_dice) = 'object'),
+  ADD CONSTRAINT player_characters_class_resources_is_object
+    CHECK (jsonb_typeof(class_resources) = 'object');
+
+COMMIT;

--- a/supabase/migrations/184_player_characters_hit_dice_class_resources.sql
+++ b/supabase/migrations/184_player_characters_hit_dice_class_resources.sql
@@ -34,13 +34,30 @@ COMMENT ON COLUMN player_characters.hit_dice IS
 COMMENT ON COLUMN player_characters.class_resources IS
   'Class-specific primary resources — JSONB. Canonical shape: {primary: {name: string, max: number, used: number}, ...}. Flexible to support multi-resource classes. Default {} means data not yet tracked (A4 header shows em-dash).';
 
--- Optional soundness check: ensure hit_dice payload keeps its shape.
+-- Optional soundness check: ensure JSONB payloads keep their object shape.
 -- (Not a hard constraint — app code is the source of truth for JSON shape;
 -- check keeps grossly malformed rows out, doesn't enforce key presence.)
-ALTER TABLE player_characters
-  ADD CONSTRAINT player_characters_hit_dice_is_object
-    CHECK (jsonb_typeof(hit_dice) = 'object'),
-  ADD CONSTRAINT player_characters_class_resources_is_object
-    CHECK (jsonb_typeof(class_resources) = 'object');
+--
+-- Guarded with DO blocks so re-running the migration locally (e.g.
+-- supabase reset) doesn't fail on duplicate constraint names. Postgres
+-- doesn't support `ADD CONSTRAINT IF NOT EXISTS` for named CHECK
+-- constraints, so the DO/EXCEPTION pattern is the idiomatic fallback.
+DO $$
+BEGIN
+  ALTER TABLE player_characters
+    ADD CONSTRAINT player_characters_hit_dice_is_object
+      CHECK (jsonb_typeof(hit_dice) = 'object');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE player_characters
+    ADD CONSTRAINT player_characters_class_resources_is_object
+      CHECK (jsonb_typeof(class_resources) = 'object');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
 
 COMMIT;


### PR DESCRIPTION
## Resumo

Fills the schema gap surfaced in PR #52 A4 header review: canonical §13.1 header format (`HD x/y · CD x/y · Insp x · Slots`) had no backing columns, so #52 rendered em-dash placeholders. Lands the columns + TypeScript types so A4 (and Sprint 3+ HeroiTab) can hydrate real values.

## Referências

- Migration: `supabase/migrations/184_player_characters_hit_dice_class_resources.sql`
- Spec: `_bmad-output/party-mode-2026-04-22/08-design-tokens-delta.md` §13.1
- Surfaced by: PR #52 A4 adversarial review (EC-4 Insp schema note, M2 spec drift — HD/CD missing)
- Related: PR #52 `feat/ep-1-a4-header-2lines` — flip em-dash to real values post-merge

## ⚠️ Overlap note: `class_resources` vs `character_resource_trackers`

Migration 057 already provides a normalized, per-class resource tracker (`character_resource_trackers` — Ki, Rage, Wild Shape, etc.) with short/long/dawn reset cycles consumed by `lib/hooks/useResourceTrackers.ts`. The new `class_resources` JSONB column on `player_characters` is a **header-optimized mirror**, NOT the authoritative store.

**Sprint 3 wiring must avoid double-write.** Canonical flow:
1. Short-rest UI increments `character_resource_trackers.current` (source of truth).
2. A follow-up trigger OR the hook writes the summary into `class_resources.primary` so the A4 header doesn't need a join on every render.

Recommended Sprint 3 task: add a Postgres trigger OR consolidate in the `useResourceTrackers` hook to keep these in sync.

## Checklist

- [x] `rtk tsc --noEmit` — types match SQL NOT NULL (Row required, Insert/Update optional for defaults)
- [x] `rtk lint` N/A
- [x] Migration is idempotent (`IF NOT EXISTS` on columns + DO/EXCEPTION blocks on CHECK constraints)
- [x] CHECK constraints on `jsonb_typeof = 'object'` — prevents grossly malformed payloads without dictating keys
- [x] Default values match A4's em-dash placeholder behavior
- [x] "Mestre" rule: N/A (internal schema, no user-facing text)

## Review

- [x] **Não — schema infra / sem pixels visíveis → review Winston + Dani**

## Combat Parity

N/A — schema fields are Auth-only (`player_characters` is campaign-member data). Guest / Anon don't persist characters.

## Test plan

- [x] TypeScript matches SQL (Row = required NOT NULL; Insert/Update = optional w/ server defaults)
- [x] Adversarial review done — 0 blockers, 3 nits addressed in `eb190182`
- [ ] Run migration in dev Supabase → confirm `ALTER TABLE` passes, defaults applied to existing rows
- [ ] Backfill script (follow-up): `UPDATE player_characters SET hit_dice = jsonb_build_object('max', level, 'used', 0) WHERE hit_dice = '{\"max\":0,\"used\":0}' AND level IS NOT NULL;`
- [ ] A4 PR #52 amend: flip em-dash rendering to use real `character.hit_dice` / `character.class_resources.primary` when `.max > 0`
- [ ] `supabase gen types` audit — hand-rolled types should match generated

## Follow-ups (post-merge, not scope)

- App-level backfill for existing rows (`hit_dice.max = level`)
- A4 PR #52 wire to real values (1-line edit to replace em-dash)
- Sprint 3: short-rest UI increments `character_resource_trackers.current` + mirror to `class_resources.primary`; long-rest resets both
- Sprint 4: class picker seeds `class_resources.primary` from SRD class data
- `supabase gen types` run to verify hand-rolled types

🤖 Generated with [Claude Code](https://claude.com/claude-code)