### PR TITLE
fix(csp): add blob: to script-src to unblock Supabase realtime worker on webkit

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -18,7 +18,16 @@ function buildCsp(nonce: string): string {
   const isDev = process.env.NODE_ENV !== "production";
   return [
     "default-src 'self'",
-    `script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval' 'unsafe-inline' https:`,
+    // `blob:` in script-src is required because webkit (mobile-safari / iOS
+    // Safari) falls through to script-src when resolving Worker blob URLs —
+    // it does not honor `worker-src 'self' blob:` the way Chromium does. Beta
+    // #4 R1 enabled `worker: true` on the Supabase realtime client
+    // (lib/supabase/client.ts), which creates a blob-URL worker; without
+    // `blob:` here every webkit auth attempt crashed with "Refused to execute
+    // a script because it does not appear in the script-src directive",
+    // breaking 12 mobile-safari e2e specs (login + combat + journeys) on
+    // 2026-04-24.
+    `script-src 'nonce-${nonce}' 'strict-dynamic' 'unsafe-eval' 'unsafe-inline' blob: https:`,
     "worker-src 'self' blob:",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",


### PR DESCRIPTION
## Resumo

Mobile-safari auth 100% broken (12 webkit e2e fails on 2026-04-24). Root cause: beta #4 R1 enabled \`worker: true\` on Supabase realtime (commit \`1e549ef6\` merged via #48) → creates blob-URL Worker → webkit falls through to \`script-src\` which lacked \`blob:\` → CSP violation crashes Supabase client singleton before login can run.

One-line fix: add \`blob:\` to script-src. \`'strict-dynamic'\` keeps the trust boundary narrow (blob scripts still only under nonced parents, no arbitrary inline injection).

## Evidência (Playwright trace)

- Erro no console: \"Refused to execute a script because it does not appear in the script-src directive of the Content Security Policy\"
- Zero requests a \`/auth/v1/token?grant_type=password\` após submit
- Login form visível com campos preenchidos mas nunca submete

## Tests afetados (pre-fix) — 12 webkit fails

- \`auth/login.spec.ts\` × 3 (DM, Player, EN DM)
- \`combat/turn-advance.spec.ts\` × 3
- \`journeys/j1-first-combat.spec.ts\` × 4
- \`journeys/j2-player-join.spec.ts\` × 2

## Checklist

- [x] \`rtk tsc --noEmit\` N/A — CSP string change only
- [x] \`rtk lint\` N/A
- [x] Mestre rule N/A — CSP infra
- [x] HP tiers N/A
- [x] Combat Parity N/A — CSP affects all modes equally; desktop-chrome unaffected (was never broken)

## Review

- [x] **Não — CSP infra fix, no pixels changed → review Dev + Dani**

## Combat Parity

N/A — CSP change affects browser security policy, not combat logic. Desktop-chrome tests already pass, mobile-safari will recover. No 3-mode implication.

## Test plan

- [ ] Rodar \`NEXT_PUBLIC_PLAYER_HQ_V2=false npm run e2e:ci\` após merge → mobile-safari deve recuperar os 12 fails
- [ ] Vercel preview deploy: abrir no iOS Safari real, fazer login, confirmar sem CSP error no console
- [ ] Rich Results / Lighthouse: confirmar sem regressão de score por CSP ser menos restritivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)