### PR TITLE
feat(grimório): B1 PlayerHqShell V2 4-tab spine (EP-2)

### DIFF
--- a/components/player-hq/PlayerHqShell.tsx
+++ b/components/player-hq/PlayerHqShell.tsx
@@ -29,6 +29,8 @@ import { AttunementSection } from "./AttunementSection";
 import { ProficienciesSection } from "./ProficienciesSection";
 import { CharacterPdfExport } from "./CharacterPdfExport";
 import { PlayerHqTourProvider } from "@/components/tour/PlayerHqTourProvider";
+import { isPlayerHqV2Enabled } from "@/lib/flags/player-hq-v2";
+import { PlayerHqShellV2 } from "./v2/PlayerHqShellV2";
 
 type Tab = "map" | "sheet" | "resources" | "abilities" | "inventory" | "notes" | "quests";
 
@@ -226,7 +228,28 @@ interface PlayerHqShellProps {
   playerHqTourCompleted?: boolean;
 }
 
-export function PlayerHqShell({
+export function PlayerHqShell(props: PlayerHqShellProps) {
+  // V2 flag gate (Sprint 3 Track A · Story B1). When ON, render the new
+  // 4-tab shell; the V1 7-tab path below stays untouched until Sprint 10
+  // flips the flag in prod and the V1 file is deleted.
+  //
+  // Conditional render via separate component (PlayerHqShellV1) keeps both
+  // branches' hook orders stable per the Rules of Hooks.
+  if (isPlayerHqV2Enabled()) {
+    return (
+      <PlayerHqShellV2
+        characterId={props.characterId}
+        campaignId={props.campaignId}
+        campaignName={props.campaignName}
+        userId={props.userId}
+        playerHqTourCompleted={props.playerHqTourCompleted}
+      />
+    );
+  }
+  return <PlayerHqShellV1 {...props} />;
+}
+
+function PlayerHqShellV1({
   characterId,
   campaignId,
   campaignName,

--- a/components/player-hq/v2/ArsenalTab.tsx
+++ b/components/player-hq/v2/ArsenalTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import type { PlayerHqV2TabProps } from "./HeroiTab";
 
 /**
  * ArsenalTab — stub placeholder for Sprint 3 Track A (Story B1).
@@ -9,7 +10,7 @@ import { useTranslations } from "next-intl";
  *   AbilitiesSection + AttunementSection + BagOfHolding + PersonalInventory
  * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
  */
-export function ArsenalTab() {
+export function ArsenalTab(_props: PlayerHqV2TabProps) {
   const t = useTranslations("player_hq");
   return (
     <div

--- a/components/player-hq/v2/ArsenalTab.tsx
+++ b/components/player-hq/v2/ArsenalTab.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+/**
+ * ArsenalTab — stub placeholder for Sprint 3 Track A (Story B1).
+ *
+ * Track B fills this with the composition of:
+ *   AbilitiesSection + AttunementSection + BagOfHolding + PersonalInventory
+ * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ */
+export function ArsenalTab() {
+  const t = useTranslations("player_hq");
+  return (
+    <div
+      data-testid="tab-stub-arsenal"
+      className="rounded-xl border border-dashed border-border bg-card/40 p-6 text-center text-sm text-muted-foreground"
+    >
+      {t("tabs.arsenal")}
+    </div>
+  );
+}

--- a/components/player-hq/v2/DiarioTab.tsx
+++ b/components/player-hq/v2/DiarioTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import type { PlayerHqV2TabProps } from "./HeroiTab";
 
 /**
  * DiarioTab — stub placeholder for Sprint 3 Track A (Story B1).
@@ -9,7 +10,7 @@ import { useTranslations } from "next-intl";
  *   PlayerNotesSection + DmNotesInbox + NpcJournal + PlayerQuestBoard
  * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
  */
-export function DiarioTab() {
+export function DiarioTab(_props: PlayerHqV2TabProps) {
   const t = useTranslations("player_hq");
   return (
     <div

--- a/components/player-hq/v2/DiarioTab.tsx
+++ b/components/player-hq/v2/DiarioTab.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+/**
+ * DiarioTab — stub placeholder for Sprint 3 Track A (Story B1).
+ *
+ * Track B fills this with the composition of:
+ *   PlayerNotesSection + DmNotesInbox + NpcJournal + PlayerQuestBoard
+ * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ */
+export function DiarioTab() {
+  const t = useTranslations("player_hq");
+  return (
+    <div
+      data-testid="tab-stub-diario"
+      className="rounded-xl border border-dashed border-border bg-card/40 p-6 text-center text-sm text-muted-foreground"
+    >
+      {t("tabs.diario")}
+    </div>
+  );
+}

--- a/components/player-hq/v2/HeroiTab.tsx
+++ b/components/player-hq/v2/HeroiTab.tsx
@@ -10,7 +10,14 @@ import { useTranslations } from "next-intl";
  *   ActiveEffectsPanel + SpellSlotsHq + ResourceTrackerList + SpellListSection
  * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
  */
-export function HeroiTab() {
+
+export interface PlayerHqV2TabProps {
+  characterId: string;
+  campaignId: string;
+  userId: string;
+}
+
+export function HeroiTab(_props: PlayerHqV2TabProps) {
   const t = useTranslations("player_hq");
   return (
     <div

--- a/components/player-hq/v2/HeroiTab.tsx
+++ b/components/player-hq/v2/HeroiTab.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+/**
+ * HeroiTab — stub placeholder for Sprint 3 Track A (Story B1).
+ *
+ * Track B fills this with the composition of:
+ *   CharacterStatusPanel + CharacterCoreStats + ProficienciesSection +
+ *   ActiveEffectsPanel + SpellSlotsHq + ResourceTrackerList + SpellListSection
+ * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ */
+export function HeroiTab() {
+  const t = useTranslations("player_hq");
+  return (
+    <div
+      data-testid="tab-stub-heroi"
+      className="rounded-xl border border-dashed border-border bg-card/40 p-6 text-center text-sm text-muted-foreground"
+    >
+      {t("tabs.heroi")}
+    </div>
+  );
+}

--- a/components/player-hq/v2/MapaTab.tsx
+++ b/components/player-hq/v2/MapaTab.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+/**
+ * MapaTab — stub placeholder for Sprint 3 Track A (Story B1).
+ *
+ * Track B fills this with PlayerMindMap (unchanged).
+ * See [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ */
+export function MapaTab() {
+  const t = useTranslations("player_hq");
+  return (
+    <div
+      data-testid="tab-stub-mapa"
+      className="rounded-xl border border-dashed border-border bg-card/40 p-6 text-center text-sm text-muted-foreground"
+    >
+      {t("tabs.mapa")}
+    </div>
+  );
+}

--- a/components/player-hq/v2/MapaTab.tsx
+++ b/components/player-hq/v2/MapaTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import type { PlayerHqV2TabProps } from "./HeroiTab";
 
 /**
  * MapaTab — stub placeholder for Sprint 3 Track A (Story B1).
@@ -8,7 +9,7 @@ import { useTranslations } from "next-intl";
  * Track B fills this with PlayerMindMap (unchanged).
  * See [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
  */
-export function MapaTab() {
+export function MapaTab(_props: PlayerHqV2TabProps) {
   const t = useTranslations("player_hq");
   return (
     <div

--- a/components/player-hq/v2/PlayerHqShellV2.tsx
+++ b/components/player-hq/v2/PlayerHqShellV2.tsx
@@ -142,6 +142,7 @@ export function PlayerHqShellV2({
   characterId,
   campaignId,
   campaignName,
+  userId,
   playerHqTourCompleted = true,
   initialTab,
 }: PlayerHqShellV2Props) {
@@ -262,10 +263,38 @@ export function PlayerHqShellV2({
         aria-labelledby={`tab-v2-${activeTab}`}
         className="animate-in fade-in-0 duration-150"
       >
-        {activeTab === "heroi" && <HeroiTab />}
-        {activeTab === "arsenal" && <ArsenalTab />}
-        {activeTab === "diario" && <DiarioTab />}
-        {activeTab === "mapa" && <MapaTab />}
+        {/* Stubs accept the same context props each tab will need once
+            B2 fills the wrappers (PlayerMindMap needs userId,
+            BagOfHolding needs campaignId, etc.). Forwarding now keeps
+            the prop contract stable so B2 PRs are pure additions. */}
+        {activeTab === "heroi" && (
+          <HeroiTab
+            characterId={characterId}
+            campaignId={campaignId}
+            userId={userId}
+          />
+        )}
+        {activeTab === "arsenal" && (
+          <ArsenalTab
+            characterId={characterId}
+            campaignId={campaignId}
+            userId={userId}
+          />
+        )}
+        {activeTab === "diario" && (
+          <DiarioTab
+            characterId={characterId}
+            campaignId={campaignId}
+            userId={userId}
+          />
+        )}
+        {activeTab === "mapa" && (
+          <MapaTab
+            characterId={characterId}
+            campaignId={campaignId}
+            userId={userId}
+          />
+        )}
       </div>
     </div>
   );

--- a/components/player-hq/v2/PlayerHqShellV2.tsx
+++ b/components/player-hq/v2/PlayerHqShellV2.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import {
+  Heart,
+  Package,
+  BookOpen,
+  Network,
+  ChevronLeft,
+  type LucideIcon,
+} from "lucide-react";
+import { ClassIcon } from "@/components/character/ClassIcon";
+import { CharacterEditSheet } from "../CharacterEditSheet";
+import { CharacterPdfExport } from "../CharacterPdfExport";
+import { useCharacterStatus } from "@/lib/hooks/useCharacterStatus";
+import { PlayerHqTourProvider } from "@/components/tour/PlayerHqTourProvider";
+import { HeroiTab } from "./HeroiTab";
+import { ArsenalTab } from "./ArsenalTab";
+import { DiarioTab } from "./DiarioTab";
+import { MapaTab } from "./MapaTab";
+
+/**
+ * V2 Player HQ Shell — 4-tab spine (Sprint 3 Track A · Story B1).
+ *
+ * Locked nomenclature per
+ * [PRD-EPICO-CONSOLIDADO §2 decisions #28/#29/#34/#35](../../../_bmad-output/party-mode-2026-04-22/PRD-EPICO-CONSOLIDADO.md):
+ *
+ *   Herói · Arsenal · Diário · Mapa
+ *
+ * Icons (Lucide, gold #D4A853):
+ *   Heart  / Package / BookOpen / Network
+ *
+ * This shell intentionally renders STUB content for each tab. Track B fills
+ * the stubs with the real component compositions per
+ * [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ *
+ * Flag-gated: only mounted when `isPlayerHqV2Enabled()` returns `true`. The
+ * V1 shell ([PlayerHqShell.tsx](../PlayerHqShell.tsx)) remains untouched and
+ * stays the default until Sprint 10 flips the flag in prod.
+ */
+
+type TabV2 = "heroi" | "arsenal" | "diario" | "mapa";
+
+const TABS_V2: Array<{ key: TabV2; icon: LucideIcon; labelKey: string }> = [
+  { key: "heroi", icon: Heart, labelKey: "tabs.heroi" },
+  { key: "arsenal", icon: Package, labelKey: "tabs.arsenal" },
+  { key: "diario", icon: BookOpen, labelKey: "tabs.diario" },
+  { key: "mapa", icon: Network, labelKey: "tabs.mapa" },
+];
+
+function TabBarV2({
+  activeTab,
+  onTabChange,
+  t,
+}: {
+  activeTab: TabV2;
+  onTabChange: (tab: TabV2) => void;
+  t: ReturnType<typeof useTranslations<"player_hq">>;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showFade, setShowFade] = useState(false);
+
+  const checkOverflow = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setShowFade(
+      el.scrollWidth > el.clientWidth &&
+        el.scrollLeft + el.clientWidth < el.scrollWidth - 4,
+    );
+  }, []);
+
+  useEffect(() => {
+    checkOverflow();
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", checkOverflow, { passive: true });
+    window.addEventListener("resize", checkOverflow);
+    return () => {
+      el.removeEventListener("scroll", checkOverflow);
+      window.removeEventListener("resize", checkOverflow);
+    };
+  }, [checkOverflow]);
+
+  return (
+    <div className="relative">
+      <div
+        ref={scrollRef}
+        className="flex border-b border-border overflow-x-auto scrollbar-hide"
+        role="tablist"
+        aria-label={t("tabs.aria_tablist")}
+        data-testid="player-hq-v2-tablist"
+      >
+        {TABS_V2.map(({ key, icon: Icon, labelKey }) => {
+          const isActive = activeTab === key;
+          return (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              id={`tab-v2-${key}`}
+              aria-selected={isActive}
+              aria-controls={`panel-v2-${key}`}
+              data-tour-id={`hq-tab-${key}`}
+              data-testid={`player-hq-v2-tab-${key}`}
+              onClick={() => onTabChange(key)}
+              className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                isActive
+                  ? "border-amber-400 text-amber-400"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              <Icon
+                className={`w-4 h-4 ${isActive ? "" : "text-[#D4A853]"}`}
+                aria-hidden
+              />
+              {t(labelKey)}
+            </button>
+          );
+        })}
+      </div>
+      {showFade && (
+        <div className="absolute right-0 top-0 bottom-0 w-8 pointer-events-none bg-gradient-to-l from-background to-transparent" />
+      )}
+    </div>
+  );
+}
+
+export interface PlayerHqShellV2Props {
+  characterId: string;
+  campaignId: string;
+  campaignName: string;
+  userId: string;
+  /** Whether the HQ tour has been completed — false triggers the tour */
+  playerHqTourCompleted?: boolean;
+  /** Optional initial tab (set by SSR from `?tab=` query param). */
+  initialTab?: TabV2;
+}
+
+export function PlayerHqShellV2({
+  characterId,
+  campaignId,
+  campaignName,
+  playerHqTourCompleted = true,
+  initialTab,
+}: PlayerHqShellV2Props) {
+  const t = useTranslations("player_hq");
+  const [activeTab, setActiveTab] = useState<TabV2>(initialTab ?? "heroi");
+
+  const {
+    character,
+    loading: charLoading,
+    saveField,
+  } = useCharacterStatus(characterId);
+
+  if (charLoading) {
+    return (
+      <div className="space-y-3 animate-pulse" data-testid="player-hq-v2-loading">
+        <div className="h-8 bg-white/5 rounded w-1/3" />
+        <div className="h-40 bg-white/5 rounded-xl" />
+        <div className="h-32 bg-white/5 rounded-xl" />
+      </div>
+    );
+  }
+
+  if (!character) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">{t("sheet.no_character")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="space-y-3 pb-20"
+      data-testid="player-hq-v2-root"
+      data-active-tab={activeTab}
+    >
+      {/* Tour reuses the same provider as V1; tour anchors stay valid via
+          `data-tour-id="hq-tab-*"` which we re-emit above. */}
+      <PlayerHqTourProvider shouldAutoStart={!playerHqTourCompleted} />
+
+      {/* Header — identity row carried over from V1 (line 1 only for now;
+          quick-resources row 2 is reworked by A4 PR). */}
+      <div className="flex flex-col gap-1.5" data-tour-id="hq-header">
+        <div className="flex items-center gap-3 min-w-0">
+          <Link
+            href={`/app/campaigns/${campaignId}`}
+            aria-label={t("header.back_aria")}
+            className="text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </Link>
+          <div className="min-w-0 flex-1 flex items-center gap-1.5">
+            <ClassIcon
+              characterClass={character.class}
+              size={20}
+              className="text-amber-400 flex-shrink-0"
+            />
+            <h1 className="text-lg font-semibold text-foreground truncate">
+              {[
+                campaignName,
+                character.name,
+                [character.race, character.class].filter(Boolean).join("/") ||
+                  null,
+                character.level
+                  ? `${t("sheet.level_prefix")}${character.level}`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </h1>
+          </div>
+          <CharacterPdfExport
+            character={{
+              ...character,
+              proficiencies: character.proficiencies ?? {},
+            }}
+          />
+          <CharacterEditSheet
+            character={character}
+            onSave={saveField}
+            translations={{
+              edit_character: t("edit.edit_character"),
+              identity: t("edit.identity"),
+              combat_stats: t("edit.combat_stats"),
+              attributes: t("edit.attributes"),
+              notes: t("edit.notes"),
+              name: t("edit.name"),
+              race: t("edit.race"),
+              class: t("edit.class"),
+              level: t("edit.level"),
+              subclass: t("edit.subclass"),
+              subrace: t("edit.subrace"),
+              background: t("edit.background"),
+              alignment: t("edit.alignment"),
+              max_hp: t("edit.max_hp"),
+              ac: t("edit.ac"),
+              speed: t("edit.speed"),
+              initiative_bonus: t("edit.initiative_bonus"),
+              spell_save_dc: t("edit.spell_save_dc"),
+              str: t("edit.str"),
+              dex: t("edit.dex"),
+              con: t("edit.con"),
+              int: t("edit.int"),
+              wis: t("edit.wis"),
+              cha: t("edit.cha"),
+              notes_placeholder: t("edit.notes_placeholder"),
+            }}
+          />
+        </div>
+      </div>
+
+      <TabBarV2 activeTab={activeTab} onTabChange={setActiveTab} t={t} />
+
+      <div
+        key={activeTab}
+        id={`panel-v2-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`tab-v2-${activeTab}`}
+        className="animate-in fade-in-0 duration-150"
+      >
+        {activeTab === "heroi" && <HeroiTab />}
+        {activeTab === "arsenal" && <ArsenalTab />}
+        {activeTab === "diario" && <DiarioTab />}
+        {activeTab === "mapa" && <MapaTab />}
+      </div>
+    </div>
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1147,6 +1147,10 @@
       "quests": "Quests",
       "map": "Map",
       "abilities": "Abilities",
+      "heroi": "Herói",
+      "arsenal": "Arsenal",
+      "diario": "Diário",
+      "mapa": "Mapa",
       "aria_tablist": "Character tabs"
     },
     "header": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1147,6 +1147,10 @@
       "quests": "Quests",
       "map": "Mapa",
       "abilities": "Habilidades",
+      "heroi": "Herói",
+      "arsenal": "Arsenal",
+      "diario": "Diário",
+      "mapa": "Mapa",
       "aria_tablist": "Abas do personagem"
     },
     "header": {


### PR DESCRIPTION
## Sprint 3 Track A · Story B1

Adds a flag-gated V2 shell for the Player HQ Redesign (Grimório). When
`NEXT_PUBLIC_PLAYER_HQ_V2=true`, players see the new 4-tab spine
(Herói / Arsenal / Diário / Mapa). Flag OFF: V1 7-tab shell unchanged.

**Wireframes / spec:**
- [09-implementation-plan.md §B1](_bmad-output/party-mode-2026-04-22/09-implementation-plan.md)
- [02-topologia-navegacao.md](_bmad-output/party-mode-2026-04-22/02-topologia-navegacao.md)
- [PRD-EPICO-CONSOLIDADO §2 decisions #28, #29, #34, #35](_bmad-output/party-mode-2026-04-22/PRD-EPICO-CONSOLIDADO.md)
- [12-reuse-matrix.md §2.1](_bmad-output/party-mode-2026-04-22/12-reuse-matrix.md)

## What changed
- New `components/player-hq/v2/PlayerHqShellV2.tsx` — 4-tab shell with Lucide gold icons (`Heart` / `Package` / `BookOpen` / `Network`).
- New stubs `components/player-hq/v2/{Heroi,Arsenal,Diario,Mapa}Tab.tsx` — each renders `data-testid=\"tab-stub-{name}\"` placeholder for Track B to fill.
- `components/player-hq/PlayerHqShell.tsx` — early return to `PlayerHqShellV2` when `isPlayerHqV2Enabled()` is true. V1 body extracted into a `PlayerHqShellV1` inner component to keep hook orders stable.
- `messages/en.json` + `messages/pt-BR.json` — added `tabs.heroi/arsenal/diario/mapa` (PT-BR labels in both locales per glossário ubíquo). Old keys kept — V1 still uses them.

## AC checklist
- [x] Flag OFF: V1 7-tab shell renders unchanged (V1 extracted into inner component, all 7 tabs + hooks intact).
- [x] Flag ON: V2 4-tab shell with Herói default, icons gold, all 4 stubs have `data-testid=\"tab-stub-{heroi|arsenal|diario|mapa}\"`.
- [x] `tsc --noEmit` clean.
- [x] No regression in `e2e/journeys/j21-player-ui-panels.spec.ts`, `e2e/features/active-effects.spec.ts`, `e2e/campaign/mind-map.spec.ts` — those tests run with default env (flag OFF) and only touch V1 surfaces.

## Cleanup flag
`components/player-hq/NewBadge.tsx` — verified via grep to have **zero consumers** in the codebase. Recommend deletion in Sprint 10 alongside V1 shell removal. Not deleted in this PR.

## Combat parity
N/A — pure UI flag/topology change, no combat code touched. The V2 stubs do not render combat surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>