### PR TITLE
feat(grimório): B3 deep-link back-compat redirects (EP-2)

### DIFF
--- a/app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx
+++ b/app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx
@@ -3,17 +3,74 @@ import { createClient } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { getCampaignMembership } from "@/lib/supabase/campaign-membership";
 import { PlayerHqShell } from "@/components/player-hq/PlayerHqShell";
+import { isPlayerHqV2Enabled } from "@/lib/flags/player-hq-v2";
 
 export const metadata: Metadata = {
   title: "Player HQ",
 };
 
+/**
+ * Sprint 3 Track A · Story B3 — back-compat for legacy `?tab=` deep links.
+ *
+ * When the V2 flag is ON and a legacy V1 tab key arrives in the query
+ * string, we issue a server-side `redirect()` so there is no client flash
+ * and browser history stays sane. When the flag is OFF, the helper returns
+ * `null` and behavior is unchanged (V1 ignores the param at SSR; the
+ * legacy shell consumes it client-side as it already did).
+ *
+ * Mapping per [09-implementation-plan.md §B3](../../../../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md):
+ *
+ *   ?tab=ficha        → ?tab=heroi
+ *   ?tab=recursos     → ?tab=heroi&section=recursos
+ *   ?tab=habilidades  → ?tab=arsenal&section=habilidades
+ *   ?tab=inventario   → ?tab=arsenal
+ *   ?tab=notas        → ?tab=diario&section=notas
+ *   ?tab=quests       → ?tab=diario&section=quests
+ *   ?tab=map          → ?tab=mapa
+ */
+const LEGACY_TAB_REDIRECTS: Record<
+  string,
+  { tab: "heroi" | "arsenal" | "diario" | "mapa"; section?: string }
+> = {
+  ficha: { tab: "heroi" },
+  recursos: { tab: "heroi", section: "recursos" },
+  habilidades: { tab: "arsenal", section: "habilidades" },
+  inventario: { tab: "arsenal" },
+  notas: { tab: "diario", section: "notas" },
+  quests: { tab: "diario", section: "quests" },
+  map: { tab: "mapa" },
+};
+
+function buildRedirectTarget(
+  campaignId: string,
+  tab: string,
+  section?: string,
+): string {
+  const params = new URLSearchParams({ tab });
+  if (section) params.set("section", section);
+  return `/app/campaigns/${campaignId}/sheet?${params.toString()}`;
+}
+
 export default async function PlayerHqSheetPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { id } = await params;
+  const sp = await searchParams;
+
+  // Deep-link back-compat (B3) — only active when V2 flag is on.
+  if (isPlayerHqV2Enabled()) {
+    const rawTab = sp?.tab;
+    const tab = Array.isArray(rawTab) ? rawTab[0] : rawTab;
+    if (typeof tab === "string" && tab in LEGACY_TAB_REDIRECTS) {
+      const mapping = LEGACY_TAB_REDIRECTS[tab];
+      redirect(buildRedirectTarget(id, mapping.tab, mapping.section));
+    }
+  }
+
   const supabase = await createClient();
   const {
     data: { user },

--- a/app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx
+++ b/app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx
@@ -4,6 +4,11 @@ import { redirect } from "next/navigation";
 import { getCampaignMembership } from "@/lib/supabase/campaign-membership";
 import { PlayerHqShell } from "@/components/player-hq/PlayerHqShell";
 import { isPlayerHqV2Enabled } from "@/lib/flags/player-hq-v2";
+import {
+  LEGACY_TAB_REDIRECTS,
+  buildRedirectTarget,
+  resolveTabParam,
+} from "@/lib/navigation/legacy-tab-redirects";
 
 export const metadata: Metadata = {
   title: "Player HQ",
@@ -18,38 +23,9 @@ export const metadata: Metadata = {
  * `null` and behavior is unchanged (V1 ignores the param at SSR; the
  * legacy shell consumes it client-side as it already did).
  *
- * Mapping per [09-implementation-plan.md §B3](../../../../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md):
- *
- *   ?tab=ficha        → ?tab=heroi
- *   ?tab=recursos     → ?tab=heroi&section=recursos
- *   ?tab=habilidades  → ?tab=arsenal&section=habilidades
- *   ?tab=inventario   → ?tab=arsenal
- *   ?tab=notas        → ?tab=diario&section=notas
- *   ?tab=quests       → ?tab=diario&section=quests
- *   ?tab=map          → ?tab=mapa
+ * Mapping + URL builder live in `lib/navigation/legacy-tab-redirects.ts`
+ * so they can be unit-tested in isolation (see neighboring `__tests__/`).
  */
-const LEGACY_TAB_REDIRECTS: Record<
-  string,
-  { tab: "heroi" | "arsenal" | "diario" | "mapa"; section?: string }
-> = {
-  ficha: { tab: "heroi" },
-  recursos: { tab: "heroi", section: "recursos" },
-  habilidades: { tab: "arsenal", section: "habilidades" },
-  inventario: { tab: "arsenal" },
-  notas: { tab: "diario", section: "notas" },
-  quests: { tab: "diario", section: "quests" },
-  map: { tab: "mapa" },
-};
-
-function buildRedirectTarget(
-  campaignId: string,
-  tab: string,
-  section?: string,
-): string {
-  const params = new URLSearchParams({ tab });
-  if (section) params.set("section", section);
-  return `/app/campaigns/${campaignId}/sheet?${params.toString()}`;
-}
 
 export default async function PlayerHqSheetPage({
   params,
@@ -63,11 +39,10 @@ export default async function PlayerHqSheetPage({
 
   // Deep-link back-compat (B3) — only active when V2 flag is on.
   if (isPlayerHqV2Enabled()) {
-    const rawTab = sp?.tab;
-    const tab = Array.isArray(rawTab) ? rawTab[0] : rawTab;
+    const tab = resolveTabParam(sp);
     if (typeof tab === "string" && tab in LEGACY_TAB_REDIRECTS) {
       const mapping = LEGACY_TAB_REDIRECTS[tab];
-      redirect(buildRedirectTarget(id, mapping.tab, mapping.section));
+      redirect(buildRedirectTarget(id, mapping, sp));
     }
   }
 

--- a/lib/navigation/__tests__/legacy-tab-redirects.test.ts
+++ b/lib/navigation/__tests__/legacy-tab-redirects.test.ts
@@ -1,0 +1,148 @@
+import {
+  LEGACY_TAB_REDIRECTS,
+  buildRedirectTarget,
+  resolveTabParam,
+} from "../legacy-tab-redirects";
+
+describe("LEGACY_TAB_REDIRECTS", () => {
+  it("covers all 7 legacy tab keys per spec §B3", () => {
+    expect(Object.keys(LEGACY_TAB_REDIRECTS).sort()).toEqual(
+      [
+        "ficha",
+        "habilidades",
+        "inventario",
+        "map",
+        "notas",
+        "quests",
+        "recursos",
+      ].sort(),
+    );
+  });
+
+  it.each([
+    ["ficha", { tab: "heroi" }],
+    ["recursos", { tab: "heroi", section: "recursos" }],
+    ["habilidades", { tab: "arsenal", section: "habilidades" }],
+    ["inventario", { tab: "arsenal" }],
+    ["notas", { tab: "diario", section: "notas" }],
+    ["quests", { tab: "diario", section: "quests" }],
+    ["map", { tab: "mapa" }],
+  ] as const)("maps %s correctly", (legacy, expected) => {
+    expect(LEGACY_TAB_REDIRECTS[legacy]).toEqual(expected);
+  });
+
+  it("does not include any V2 canonical key (no redirect loop risk)", () => {
+    const v2Tabs = ["heroi", "arsenal", "diario", "mapa"];
+    for (const v2 of v2Tabs) {
+      expect(LEGACY_TAB_REDIRECTS).not.toHaveProperty(v2);
+    }
+  });
+});
+
+describe("resolveTabParam", () => {
+  it("returns the string value when tab is a single string", () => {
+    expect(resolveTabParam({ tab: "ficha" })).toBe("ficha");
+  });
+
+  it("returns the first value when tab is an array", () => {
+    expect(resolveTabParam({ tab: ["ficha", "recursos"] })).toBe("ficha");
+  });
+
+  it("returns undefined when tab is missing", () => {
+    expect(resolveTabParam({})).toBeUndefined();
+    expect(resolveTabParam(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when tab is explicitly undefined", () => {
+    expect(resolveTabParam({ tab: undefined })).toBeUndefined();
+  });
+});
+
+describe("buildRedirectTarget", () => {
+  const cid = "abc-123";
+
+  it("builds a basic /sheet URL with tab only", () => {
+    const url = buildRedirectTarget(cid, { tab: "heroi" }, {});
+    expect(url).toBe(`/app/campaigns/${cid}/sheet?tab=heroi`);
+  });
+
+  it("includes section when mapping defines one", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "heroi", section: "recursos" },
+      {},
+    );
+    expect(url).toBe(`/app/campaigns/${cid}/sheet?tab=heroi&section=recursos`);
+  });
+
+  it("preserves other query params (e.g. utm_source, debug)", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "heroi" },
+      { tab: "ficha", utm_source: "recap", debug: "true" },
+    );
+    // URLSearchParams.toString preserves insertion order — we set non-tab
+    // params first, then tab, then optional section.
+    expect(url).toContain("utm_source=recap");
+    expect(url).toContain("debug=true");
+    expect(url).toContain("tab=heroi");
+    expect(url).not.toContain("tab=ficha");
+  });
+
+  it("strips the legacy tab and overwrites with mapping.tab", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "arsenal" },
+      { tab: "habilidades" },
+    );
+    expect(url).toContain("tab=arsenal");
+    expect(url).not.toContain("tab=habilidades");
+  });
+
+  it("overwrites incoming section when mapping defines one", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "diario", section: "quests" },
+      { tab: "quests", section: "stale-value" },
+    );
+    expect(url).toContain("section=quests");
+    expect(url).not.toContain("section=stale-value");
+  });
+
+  it("does NOT inject section when mapping omits it (drops incoming section too)", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "arsenal" },
+      { tab: "inventario", section: "leftover" },
+    );
+    expect(url).not.toContain("section=");
+  });
+
+  it("URL-encodes preserved param values", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "diario" },
+      { tab: "notas", note: "hello world" },
+    );
+    expect(url).toContain("note=hello+world");
+  });
+
+  it("collapses array-valued preserved params to first value", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "arsenal" },
+      { tab: "habilidades", filter: ["a", "b"] },
+    );
+    expect(url).toContain("filter=a");
+    expect(url).not.toContain("filter=b");
+  });
+
+  it("ignores undefined-valued preserved params", () => {
+    const url = buildRedirectTarget(
+      cid,
+      { tab: "heroi" },
+      { tab: "ficha", missing: undefined },
+    );
+    expect(url).not.toContain("missing=");
+  });
+});

--- a/lib/navigation/legacy-tab-redirects.ts
+++ b/lib/navigation/legacy-tab-redirects.ts
@@ -1,0 +1,79 @@
+/**
+ * Sprint 3 Track A · Story B3 — back-compat for legacy `?tab=` deep links.
+ *
+ * Pure helpers, extracted from `app/.../sheet/page.tsx` so the mapping +
+ * URL builder can be unit-tested without spinning up Next.js routing.
+ *
+ * Mapping per [09-implementation-plan.md §B3](../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md):
+ *
+ *   ?tab=ficha        → ?tab=heroi
+ *   ?tab=recursos     → ?tab=heroi&section=recursos
+ *   ?tab=habilidades  → ?tab=arsenal&section=habilidades
+ *   ?tab=inventario   → ?tab=arsenal
+ *   ?tab=notas        → ?tab=diario&section=notas
+ *   ?tab=quests       → ?tab=diario&section=quests
+ *   ?tab=map          → ?tab=mapa
+ */
+
+export type V2Tab = "heroi" | "arsenal" | "diario" | "mapa";
+
+export const LEGACY_TAB_REDIRECTS: Record<
+  string,
+  { tab: V2Tab; section?: string }
+> = {
+  ficha: { tab: "heroi" },
+  recursos: { tab: "heroi", section: "recursos" },
+  habilidades: { tab: "arsenal", section: "habilidades" },
+  inventario: { tab: "arsenal" },
+  notas: { tab: "diario", section: "notas" },
+  quests: { tab: "diario", section: "quests" },
+  map: { tab: "mapa" },
+};
+
+export type IncomingSearchParams = Record<
+  string,
+  string | string[] | undefined
+>;
+
+/**
+ * Resolve the incoming `?tab=` value to a single string (Next.js search
+ * params can be arrays when a key repeats).
+ */
+export function resolveTabParam(
+  searchParams: IncomingSearchParams | undefined,
+): string | undefined {
+  const raw = searchParams?.tab;
+  if (Array.isArray(raw)) return raw[0];
+  return typeof raw === "string" ? raw : undefined;
+}
+
+/**
+ * Build the target URL for a redirect. Preserves all incoming query params
+ * other than `tab` and `section` so things like `?utm_source=recap` or
+ * `?debug=true` survive — the AC explicitly calls out Mestre-shared recap
+ * URLs that may carry attribution params.
+ */
+export function buildRedirectTarget(
+  campaignId: string,
+  mapping: { tab: V2Tab; section?: string },
+  searchParams: IncomingSearchParams | undefined,
+): string {
+  const params = new URLSearchParams();
+
+  // Preserve incoming params except `tab` (we overwrite) and `section`
+  // (we may overwrite below if mapping defines one). For repeated keys
+  // we keep only the first value, matching `resolveTabParam`'s behavior.
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      if (key === "tab" || key === "section") continue;
+      if (value === undefined) continue;
+      const single = Array.isArray(value) ? value[0] : value;
+      if (typeof single === "string") params.set(key, single);
+    }
+  }
+
+  params.set("tab", mapping.tab);
+  if (mapping.section) params.set("section", mapping.section);
+
+  return `/app/campaigns/${campaignId}/sheet?${params.toString()}`;
+}


### PR DESCRIPTION
## Sprint 3 Track A · Story B3

Adds SSR redirects so legacy V1 tab deep links keep working when the V2
shell is enabled. Flag-gated; no behavior change when OFF.

**Spec / wireframes:**
- [09-implementation-plan.md §B3](_bmad-output/party-mode-2026-04-22/09-implementation-plan.md)
- [02-topologia-navegacao.md §🚦](_bmad-output/party-mode-2026-04-22/02-topologia-navegacao.md)

## What changed
- `app/app/(with-sidebar)/campaigns/[id]/sheet/page.tsx` — accepts the standard Next.js `searchParams` prop. Before any auth/data fetching (cheap path), if `isPlayerHqV2Enabled()` and the incoming `?tab=` matches a legacy V1 key, calls `redirect()` from `next/navigation` to the canonical V2 URL.
- `lib/navigation/legacy-tab-redirects.ts` (new) — extracted `LEGACY_TAB_REDIRECTS` map + `buildRedirectTarget()` + `resolveTabParam()` so they're unit-testable in isolation. **Preserves other query params** (e.g. `utm_source`, `debug`) — only `tab` and `section` are overwritten.
- `lib/navigation/__tests__/legacy-tab-redirects.test.ts` (new) — 22 unit tests covering all 7 mappings, array-tab, encoding, no-redirect-loop guarantee, query-param preservation. All green.

## Mappings
| Legacy `?tab=` | New target |
|---|---|
| `ficha` | `?tab=heroi` |
| `recursos` | `?tab=heroi&section=recursos` |
| `habilidades` | `?tab=arsenal&section=habilidades` |
| `inventario` | `?tab=arsenal` |
| `notas` | `?tab=diario&section=notas` |
| `quests` | `?tab=diario&section=quests` |
| `map` | `?tab=mapa` |

## AC checklist
- [x] All 7 mappings work via SSR redirect (no client flash) — `redirect()` is server-only.
- [x] Flag OFF: behavior unchanged (helper short-circuits, page renders V1 just like before).
- [x] Browser history sane (no infinite loop) — V2 canonical keys (`heroi`/`arsenal`/`diario`/`mapa`) never appear as keys in `LEGACY_TAB_REDIRECTS`.
- [x] Other query params preserved — Mestre-shared recap URLs with `utm_source` / `debug` / etc. survive the redirect (review #63 M1 fix).
- [x] 22 unit tests green (review #63 M2 fix).

## Combat parity

N/A — pure SSR routing change. The `/sheet` route is **Auth-only** by design (PRD §28: Player HQ requires a persistent character; Guest has no campaign, Anon uses `/join/[token]` and never lands on `/sheet`). No combat surface, broadcast, or state mutation is touched. Routing redirect short-circuits **before** any auth/data fetch.

<!-- parity-intent
guest: n/a (Guest mode runs on /try and never reaches /sheet — no persistent character)
anon: n/a (Anon mode runs on /join/[token] using PlayerJoinClient, not the sheet route)
-->

Label `parity-exempt` also added as belt-and-suspenders since the gate ran before the parity-intent block was committed to the PR body.

## Depends on
- #62 (B1) — only the V2 keys are meaningful targets; merging this before B1 is safe but the redirected URLs only render correctly once V2 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>