### PR TITLE
chore(grimório): tech debt sweep — substring traps + spec relocation + dead i18n key (EP-2)

### DIFF
--- a/e2e/combat/combat-hp-edit-ribbon-anon.spec.ts
+++ b/e2e/combat/combat-hp-edit-ribbon-anon.spec.ts
@@ -58,11 +58,15 @@ test.describe("Gate Fase A — A5 HP inline ribbon for Anon /join", () => {
         return;
       }
 
-      // Legacy buttons absent.
-      const legacyMinus5 = playerPage.locator(
-        'button:has-text("-5"), button:has-text("−5")',
-      );
-      const legacyPlus5 = playerPage.locator('button:has-text("+5")');
+      // Legacy buttons absent. Use exact-match (regex anchored) so
+      // "-5" does NOT match "-50", "-15", etc. Both ASCII hyphen-minus
+      // and Unicode minus glyphs are covered.
+      const legacyMinus5 = playerPage.getByRole("button", {
+        name: /^[-−]5$/,
+      });
+      const legacyPlus5 = playerPage.getByRole("button", {
+        name: /^\+5$/,
+      });
       await expect(
         legacyMinus5,
         "anon combat ribbon must not expose legacy [-5] in V2",

--- a/e2e/guest-qa/guest-hp-edit-consistency.spec.ts
+++ b/e2e/guest-qa/guest-hp-edit-consistency.spec.ts
@@ -19,7 +19,7 @@ import {
   clearGuestState,
   addAllCombatants,
   startCombat,
-} from "../guest-qa/helpers";
+} from "./helpers";
 
 const ROSTER = [
   { name: "Hero", hp: "30", ac: "15", init: "15", role: "player" as const },
@@ -48,10 +48,13 @@ test.describe("Gate Fase A — A5 HP inline for Guest /try", () => {
     ).toBeVisible({ timeout: 15_000 });
 
     // Legacy buttons must not exist on the guest ribbon in V2.
-    const legacyMinus5 = page.locator(
-      'button:has-text("-5"), button:has-text("−5")',
-    );
-    const legacyPlus5 = page.locator('button:has-text("+5")');
+    // Use exact-match (regex anchored) so "-5" does NOT match "-50",
+    // "-15", etc. Both ASCII hyphen-minus and Unicode minus glyphs are
+    // covered because legacy markup rendered both depending on locale.
+    const legacyMinus5 = page.getByRole("button", {
+      name: /^[-−]5$/,
+    });
+    const legacyPlus5 = page.getByRole("button", { name: /^\+5$/ });
     await expect(
       legacyMinus5,
       "guest /try must not expose legacy [-5] after A5",

--- a/e2e/player-hq/sheet-ability-chips-always-visible.spec.ts
+++ b/e2e/player-hq/sheet-ability-chips-always-visible.spec.ts
@@ -56,10 +56,14 @@ test.describe("Gate Fase A — ability chips always visible (A2)", () => {
     // A2 contract: each ability label must be visible in the DOM without
     // needing to click an accordion toggle. We assert by scanning for the
     // uppercase 3-letter code (STR/DEX/...) rather than tight testids —
-    // the underlying component names may evolve.
+    // the underlying component names may evolve. Use an exact-match
+    // text locator (anchored regex) so "STR" does NOT match "STRENGTH"
+    // or "STRIKE", "INT" does NOT match "INTUITION", etc.
     for (const key of ABILITIES) {
       const upper = key.toUpperCase();
-      const label = page.locator(`text=${upper}`).first();
+      const label = page
+        .getByText(new RegExp(`^${upper}$`))
+        .first();
       await expect(
         label,
         `ability "${upper}" must be visible on /sheet without any click`,

--- a/e2e/player-hq/sheet-hp-controls-inline.spec.ts
+++ b/e2e/player-hq/sheet-hp-controls-inline.spec.ts
@@ -65,8 +65,14 @@ test.describe("Gate Fase A — A5 HP inline controls on /sheet (Auth)", () => {
     }
 
     // Legacy button absence — the canonical pattern removes these.
-    const legacyMinus5 = page.locator('button:has-text("-5"), button:has-text("−5")');
-    const legacyPlus5 = page.locator('button:has-text("+5")');
+    // Use exact-match (regex anchored) so "-5" does NOT match "-50",
+    // "-15", etc. Both ASCII hyphen-minus ("-") and Unicode minus ("−")
+    // need coverage because the legacy buttons rendered the typographic
+    // glyph in some locales.
+    const legacyMinus5 = page.getByRole("button", {
+      name: /^[-−]5$/,
+    });
+    const legacyPlus5 = page.getByRole("button", { name: /^\+5$/ });
     await expect(
       legacyMinus5,
       "legacy [-5] button must NOT render in V2 HP ribbon",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1626,7 +1626,6 @@
       "state_heading": "Post-combat state",
       "you_heading": "You",
       "party_heading": "Party",
-      "no_party": "No companions tracked.",
       "hp_label": "HP",
       "slots_heading": "Spell slots",
       "no_slots": "No spell slots tracked.",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1624,7 +1624,6 @@
       "state_heading": "Estado pós-combate",
       "you_heading": "Você",
       "party_heading": "Party",
-      "no_party": "Nenhum companheiro rastreado.",
       "hp_label": "HP",
       "slots_heading": "Espaços de magia",
       "no_slots": "Nenhum espaço de magia rastreado.",


### PR DESCRIPTION
## Summary

Three small but load-bearing fixes that reduce E2E false-pass risk before the Sprint 3 wrappers land. Independent of Track A's B1 ship — landing first to clear the runway.

### 1. Substring traps in 4 specs
The legacy \`button:has-text(\"-5\")\` matcher would match buttons whose text reads \"-50\", \"-15\", etc.; same for \`+5\` vs \`+50\`. Same trap on \`text=STR\` matching \"STRENGTH\" or \"INT\" matching \"INTUITION\". Replaced with anchored regex via \`getByRole({ name: /^[-−]5$/ })\` for HP buttons and \`getByText(/^STR$/)\` for ability codes. Covers both ASCII hyphen-minus and Unicode minus glyphs.

Files:
- \`e2e/player-hq/sheet-ability-chips-always-visible.spec.ts\`
- \`e2e/player-hq/sheet-hp-controls-inline.spec.ts\`
- \`e2e/combat/combat-hp-edit-ribbon-anon.spec.ts\` *(locator-only; no behavior change to combat flow)*
- \`e2e/guest-qa/guest-hp-edit-consistency.spec.ts\` *(locator + directory move)*

### 2. \`e2e/guest/\` → \`e2e/guest-qa/\`
The lone \`guest-hp-edit\` spec lived in a one-file \`e2e/guest/\` directory; project conventions place all guest E2Es in \`e2e/guest-qa/\`. Used \`git mv\` to preserve history, updated the import from \`../guest-qa/helpers\` to \`./helpers\`, and removed the empty directory. Verified \`playwright.config.ts\` does not whitelist \`e2e/guest/\` as a project name.

### 3. \`post_combat.no_party\` i18n key removed
Zero code consumers in either locale. The kickoff prompt referenced it as \`recap_anon.no_party\` but the actual nesting is \`player_hq.post_combat.no_party\`. Sibling keys \`you_heading\` and \`party_heading\` ARE used by \`PostCombatBanner.tsx\` and stay intact.

## Skipped (with justification)

- **\`tick\` dead state in \`lib/hooks/usePostCombatState.ts\`**: the variable IS read via \`void tick;\` (line 215) with an explicit comment that it's intentional to invalidate the memoized return identity when storage mutates from imperative helpers. Removing it would silently regress consumer re-renders after \`recordCombatEnded\`/\`dismiss\`. Combat-adjacent code, left intact per kickoff guidance.

## Verified

- \`rtk tsc --noEmit\` clean
- \`rtk npm run e2e -- --list\` on all 4 affected specs parses cleanly (8 tests across 2 projects)

## Test plan

- [ ] Verify CI green
- [ ] No combat/sheet behavior changes — locators only
- [ ] Spec relocation preserves git blame via \`git log --follow\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)