### PR TITLE
feat(grimório): B4 usePlayerHqTabState hook + 24h TTL (EP-2)

### DIFF
--- a/lib/hooks/__tests__/usePlayerHqTabState.test.ts
+++ b/lib/hooks/__tests__/usePlayerHqTabState.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit coverage for `usePlayerHqTabState` (Sprint 3 Track A · Story B4).
+ *
+ * The hook is pure-ish: branching is driven by storage, optional
+ * `initialTab`, and an injectable clock. We assert each branch from
+ * the AC checklist:
+ *
+ *   - First visit: returns 'heroi'
+ *   - Switch tab: persists to localStorage with `savedAt`
+ *   - Reload <24h: restores stored tab
+ *   - Reload >24h: resets to 'heroi' (storage is treated as stale)
+ *   - `initialTab` (query param override): wins over storage
+ *   - Malformed/foreign storage entries are ignored gracefully
+ */
+
+import { renderHook, act } from "@testing-library/react";
+import {
+  PLAYER_HQ_TAB_TTL_MS_DEFAULT,
+  getStorageKey,
+  readPersistedTab,
+  usePlayerHqTabState,
+} from "@/lib/hooks/usePlayerHqTabState";
+
+const CAMPAIGN_ID = "camp-001";
+const T0 = 1_700_000_000_000;
+
+beforeEach(() => {
+  if (typeof window !== "undefined") {
+    window.localStorage.clear();
+  }
+});
+
+describe("readPersistedTab", () => {
+  it("returns null when no entry exists", () => {
+    expect(readPersistedTab(CAMPAIGN_ID, () => T0)).toBeNull();
+  });
+
+  it("returns the stored tab when fresh", () => {
+    window.localStorage.setItem(
+      getStorageKey(CAMPAIGN_ID),
+      JSON.stringify({ tab: "diario", savedAt: T0 }),
+    );
+    expect(readPersistedTab(CAMPAIGN_ID, () => T0 + 1_000)).toBe("diario");
+  });
+
+  it("returns null when entry is older than the TTL", () => {
+    window.localStorage.setItem(
+      getStorageKey(CAMPAIGN_ID),
+      JSON.stringify({ tab: "diario", savedAt: T0 }),
+    );
+    expect(
+      readPersistedTab(CAMPAIGN_ID, () => T0 + PLAYER_HQ_TAB_TTL_MS_DEFAULT + 1),
+    ).toBeNull();
+  });
+
+  it("returns null when the stored tab key is unknown", () => {
+    window.localStorage.setItem(
+      getStorageKey(CAMPAIGN_ID),
+      JSON.stringify({ tab: "ficha", savedAt: T0 }),
+    );
+    expect(readPersistedTab(CAMPAIGN_ID, () => T0 + 1_000)).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    window.localStorage.setItem(getStorageKey(CAMPAIGN_ID), "{not-json");
+    expect(readPersistedTab(CAMPAIGN_ID, () => T0 + 1_000)).toBeNull();
+  });
+
+  it("returns null when savedAt is missing or non-numeric", () => {
+    window.localStorage.setItem(
+      getStorageKey(CAMPAIGN_ID),
+      JSON.stringify({ tab: "diario" }),
+    );
+    expect(readPersistedTab(CAMPAIGN_ID, () => T0 + 1_000)).toBeNull();
+  });
+});
+
+describe("usePlayerHqTabState", () => {
+  it("defaults to 'heroi' on first visit (no storage, no initialTab)", () => {
+    const { result } = renderHook(() =>
+      usePlayerHqTabState(CAMPAIGN_ID, { now: () => T0 }),
+    );
+    expect(result.current.activeTab).toBe("heroi");
+  });
+
+  it("persists the chosen tab to localStorage with savedAt", () => {
+    const { result } = renderHook(() =>
+      usePlayerHqTabState(CAMPAIGN_ID, { now: () => T0 }),
+    );
+    act(() => {
+      result.current.setActiveTab("arsenal");
+    });
+    expect(result.current.activeTab).toBe("arsenal");
+    const raw = window.localStorage.getItem(getStorageKey(CAMPAIGN_ID));
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.tab).toBe("arsenal");
+    expect(parsed.savedAt).toBe(T0);
+  });
+
+  it("restores the stored tab on reload within the TTL", () => {
+    window.localStorage.setItem(
+      getStorageKey(CAMPAIGN_ID),
+      JSON.stringify({ tab: "mapa", savedAt: T0 }),
+    );
+    const { result } = renderHook(() =>
+      usePlayerHqTabState(CAMPAIGN_ID, { now: () => T0 + 1_000 }),
+    );
+    expect(result.current.activeTab).toBe("mapa");
+  });
+
+  it("resets to 'heroi' when the stored entry is older than the TTL", () => {
+    window.localStorage.setItem(
+      getStorageKey(CAMPAIGN_ID),
+      JSON.stringify({ tab: "mapa", savedAt: T0 }),
+    );
+    const { result } = renderHook(() =>
+      usePlayerHqTabState(CAMPAIGN_ID, {
+        now: () => T0 + PLAYER_HQ_TAB_TTL_MS_DEFAULT + 1,
+      }),
+    );
+    expect(result.current.activeTab).toBe("heroi");
+  });
+
+  it("query param (initialTab) wins over a fresh stored value", () => {
+    window.localStorage.setItem(
+      getStorageKey(CAMPAIGN_ID),
+      JSON.stringify({ tab: "mapa", savedAt: T0 }),
+    );
+    const { result } = renderHook(() =>
+      usePlayerHqTabState(CAMPAIGN_ID, {
+        initialTab: "diario",
+        now: () => T0 + 1_000,
+      }),
+    );
+    expect(result.current.activeTab).toBe("diario");
+  });
+
+  it("namespaces storage by campaignId", () => {
+    window.localStorage.setItem(
+      getStorageKey("other-campaign"),
+      JSON.stringify({ tab: "arsenal", savedAt: T0 }),
+    );
+    const { result } = renderHook(() =>
+      usePlayerHqTabState(CAMPAIGN_ID, { now: () => T0 + 1_000 }),
+    );
+    // Default — the other campaign's entry must not bleed in.
+    expect(result.current.activeTab).toBe("heroi");
+  });
+});

--- a/lib/hooks/usePlayerHqTabState.ts
+++ b/lib/hooks/usePlayerHqTabState.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+/**
+ * Player HQ V2 tab state hook (Sprint 3 Track A · Story B4).
+ *
+ * Per [09-implementation-plan.md §B4](../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md):
+ *
+ *   - First visit (or > TTL): default tab is `heroi`.
+ *   - Switching a tab persists `{ tab, savedAt }` to localStorage under
+ *     `pocketdm:lastPlayerHqTab:${campaignId}`.
+ *   - Subsequent visits within 24h restore the persisted tab.
+ *   - After 24h, the entry is treated as stale and the default returns.
+ *   - When `initialTab` is provided (typically derived SSR-side from a
+ *     `?tab=` query param), it overrides storage.
+ *
+ * Dev override: when `NEXT_PUBLIC_DEBUG_TAB_TTL_MS` is set to a positive
+ * integer, that value replaces the 24h TTL so E2E specs can exercise the
+ * stale-reset branch in seconds. The override is intentionally read at
+ * call time (via `getTabTtlMs`) so test suites can mutate the env per
+ * scenario without re-importing the module.
+ *
+ * Hook contract: `{ activeTab, setActiveTab }`. Track B (PlayerHqShellV2)
+ * mounts the hook later in EP-2. This PR ships the hook + tests only —
+ * no shell wiring yet.
+ */
+
+export type PlayerHqV2Tab = "heroi" | "arsenal" | "diario" | "mapa";
+
+export const PLAYER_HQ_TAB_TTL_MS_DEFAULT = 86_400_000; // 24h
+
+export const VALID_PLAYER_HQ_V2_TABS: ReadonlyArray<PlayerHqV2Tab> = [
+  "heroi",
+  "arsenal",
+  "diario",
+  "mapa",
+];
+
+const DEFAULT_TAB: PlayerHqV2Tab = "heroi";
+
+interface PersistedTab {
+  tab: PlayerHqV2Tab;
+  savedAt: number;
+}
+
+export function getStorageKey(campaignId: string): string {
+  return `pocketdm:lastPlayerHqTab:${campaignId}`;
+}
+
+export function getTabTtlMs(): number {
+  const raw = process.env.NEXT_PUBLIC_DEBUG_TAB_TTL_MS;
+  if (!raw) return PLAYER_HQ_TAB_TTL_MS_DEFAULT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return PLAYER_HQ_TAB_TTL_MS_DEFAULT;
+  }
+  return parsed;
+}
+
+function isValidTab(value: unknown): value is PlayerHqV2Tab {
+  return (
+    typeof value === "string" &&
+    (VALID_PLAYER_HQ_V2_TABS as ReadonlyArray<string>).includes(value)
+  );
+}
+
+/**
+ * Pure helper exported for unit tests. Reads + parses + freshness-checks
+ * the stored entry, returning the persisted tab when valid+fresh, else
+ * `null`. Defensive against malformed JSON, missing fields, unknown tab
+ * keys, expired entries, and absent storage (SSR).
+ */
+export function readPersistedTab(
+  campaignId: string,
+  now: () => number = Date.now,
+  ttlMs: number = getTabTtlMs(),
+): PlayerHqV2Tab | null {
+  if (typeof window === "undefined") return null;
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(getStorageKey(campaignId));
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const candidate = parsed as Partial<PersistedTab>;
+  if (!isValidTab(candidate.tab)) return null;
+  if (typeof candidate.savedAt !== "number") return null;
+  if (now() - candidate.savedAt > ttlMs) return null;
+  return candidate.tab;
+}
+
+function writePersistedTab(
+  campaignId: string,
+  tab: PlayerHqV2Tab,
+  now: () => number,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      getStorageKey(campaignId),
+      JSON.stringify({ tab, savedAt: now() } satisfies PersistedTab),
+    );
+  } catch {
+    // localStorage may be quota-exceeded or disabled — silently skip;
+    // the hook continues to work in-memory for the current session.
+  }
+}
+
+export interface UsePlayerHqTabStateOptions {
+  /**
+   * Optional override (typically derived SSR-side from `?tab=`). When
+   * provided, takes precedence over storage on initial render. Setting
+   * a tab through the returned setter still persists to storage.
+   */
+  initialTab?: PlayerHqV2Tab;
+  /** Injectable clock for deterministic tests. */
+  now?: () => number;
+}
+
+export interface UsePlayerHqTabStateReturn {
+  activeTab: PlayerHqV2Tab;
+  setActiveTab: (tab: PlayerHqV2Tab) => void;
+}
+
+export function usePlayerHqTabState(
+  campaignId: string,
+  options: UsePlayerHqTabStateOptions = {},
+): UsePlayerHqTabStateReturn {
+  const { initialTab, now = Date.now } = options;
+
+  const [activeTab, setActiveTabState] = useState<PlayerHqV2Tab>(() => {
+    if (initialTab && isValidTab(initialTab)) return initialTab;
+    return readPersistedTab(campaignId, now) ?? DEFAULT_TAB;
+  });
+
+  const setActiveTab = useCallback(
+    (next: PlayerHqV2Tab) => {
+      setActiveTabState(next);
+      writePersistedTab(campaignId, next, now);
+    },
+    [campaignId, now],
+  );
+
+  return { activeTab, setActiveTab };
+}


### PR DESCRIPTION
## Sprint 3 Track A · Story B4

New `usePlayerHqTabState` hook persisting last-visited tab per
campaign with a 24h TTL. Track B will wire it into the V2 shell.

**Spec:** [09-implementation-plan.md §B4](_bmad-output/party-mode-2026-04-22/09-implementation-plan.md) · [02-topologia-navegacao.md §🚦](_bmad-output/party-mode-2026-04-22/02-topologia-navegacao.md)

## Contract
```ts
usePlayerHqTabState(campaignId, options?) -> { activeTab, setActiveTab }
```
Storage key `pocketdm:lastPlayerHqTab:${campaignId}`; JSON shape `{ tab, savedAt }`. TTL = `PLAYER_HQ_TAB_TTL_MS_DEFAULT` (24h); env override `NEXT_PUBLIC_DEBUG_TAB_TTL_MS` shrinks the window for E2E specs.

`options.initialTab` (typically derived SSR-side from `?tab=`) overrides storage on first render. Subsequent setter calls still persist.

## AC checklist
- [x] First visit -> 'heroi'.
- [x] Switch -> persisted with `savedAt`.
- [x] Reload <24h -> restored.
- [x] Reload >24h -> reset to 'heroi'.
- [x] `initialTab` (query param) overrides storage.
- [x] Hook NOT yet used in shell — Track B handles wiring.

## Tests
12 cases pass (`npm test usePlayerHqTabState`):
- `readPersistedTab` × 6 (no entry, fresh, expired, unknown tab, malformed JSON, missing savedAt)
- `usePlayerHqTabState` × 6 (default, persist, restore <TTL, reset >TTL, initialTab override, namespacing)

## Combat parity
N/A — pure hook, no realtime/combat surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>