### PR TITLE
feat(grimório): B5 keyboard shortcuts 1/2/3/4 + ? help overlay (EP-2)

### DIFF
--- a/components/player-hq/v2/KeyboardHelpOverlay.tsx
+++ b/components/player-hq/v2/KeyboardHelpOverlay.tsx
@@ -18,6 +18,10 @@ interface KeyboardHelpOverlayProps {
 export function KeyboardHelpOverlay({ open, onClose }: KeyboardHelpOverlayProps) {
   const t = useTranslations("player_hq.keyboard");
   const dialogRef = useRef<HTMLDivElement>(null);
+  // Element that was focused before the overlay opened, so we can
+  // return focus to it on close (a11y baseline; matches the pattern in
+  // KeyboardCheatsheet.tsx).
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   // Local Esc handler — kept here (not in the global shortcut hook) so
   // the overlay can be unmounted/remounted without the shortcut having
@@ -34,10 +38,18 @@ export function KeyboardHelpOverlay({ open, onClose }: KeyboardHelpOverlayProps)
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [open, onClose]);
 
-  // Focus the dialog on open so screen readers announce it.
+  // Focus the dialog on open so screen readers announce it; on close,
+  // hand focus back to whatever the user was on before.
   useEffect(() => {
     if (open) {
+      previousFocusRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
       dialogRef.current?.focus();
+      return () => {
+        previousFocusRef.current?.focus();
+      };
     }
   }, [open]);
 

--- a/components/player-hq/v2/KeyboardHelpOverlay.tsx
+++ b/components/player-hq/v2/KeyboardHelpOverlay.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
+
+/**
+ * Help overlay listing the V2 Player HQ keyboard shortcuts (Sprint 3
+ * Track A · Story B5). Opened by the global `?` shortcut handled in
+ * `PlayerHqKeyboardShortcuts`. Closes on Esc, on the close button, or
+ * when the backdrop is clicked.
+ */
+
+interface KeyboardHelpOverlayProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function KeyboardHelpOverlay({ open, onClose }: KeyboardHelpOverlayProps) {
+  const t = useTranslations("player_hq.keyboard");
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Local Esc handler — kept here (not in the global shortcut hook) so
+  // the overlay can be unmounted/remounted without the shortcut having
+  // to know about its state.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  // Focus the dialog on open so screen readers announce it.
+  useEffect(() => {
+    if (open) {
+      dialogRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const rows: Array<{ key: string; label: string }> = [
+    { key: "1", label: t("tab1") },
+    { key: "2", label: t("tab2") },
+    { key: "3", label: t("tab3") },
+    { key: "4", label: t("tab4") },
+    { key: "?", label: t("help") },
+    { key: "Esc", label: t("close") },
+  ];
+
+  return (
+    <div
+      role="presentation"
+      onClick={onClose}
+      data-testid="player-hq-v2-keyboard-help-backdrop"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="kbd-help-title"
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        data-testid="player-hq-v2-keyboard-help"
+        className="w-[min(420px,90vw)] rounded-xl border border-border bg-card p-5 shadow-xl outline-none"
+      >
+        <h2
+          id="kbd-help-title"
+          className="text-base font-semibold text-amber-400"
+        >
+          {t("title")}
+        </h2>
+        <ul className="mt-4 space-y-2">
+          {rows.map((row) => (
+            <li
+              key={row.key}
+              className="flex items-center justify-between gap-4 text-sm"
+            >
+              <span className="text-muted-foreground">{row.label}</span>
+              <kbd className="rounded border border-border bg-background px-2 py-0.5 text-xs font-mono text-foreground">
+                {row.key}
+              </kbd>
+            </li>
+          ))}
+        </ul>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-5 w-full rounded-md border border-border bg-background py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+        >
+          {t("close")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/player-hq/v2/PlayerHqKeyboardShortcuts.tsx
+++ b/components/player-hq/v2/PlayerHqKeyboardShortcuts.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { KeyboardHelpOverlay } from "./KeyboardHelpOverlay";
+
+/**
+ * Global keyboard shortcuts for the V2 Player HQ shell (Sprint 3 Track
+ * A · Story B5). Mounted by `PlayerHqShellV2` and ONLY by it — flag-
+ * gated indirectly through that mount path. Track A ships the shortcut
+ * surface; the shell wires `onTabChange` after merging with B1.
+ *
+ * Shortcuts:
+ *   1 / 2 / 3 / 4 — switch to Herói / Arsenal / Diário / Mapa
+ *   ?              — toggle the help overlay
+ *   Esc            — close the help overlay (handled by the overlay itself)
+ *
+ * Listener is intentionally inert when focus is inside an INPUT,
+ * TEXTAREA, SELECT, or any contenteditable element. We intentionally do
+ * NOT use `useKeyboardShortcut` here because that hook calls
+ * `preventDefault()` unconditionally — fine for letters, but for `?`
+ * (Shift+/) it can swallow legitimate text input on some keyboards.
+ * Inline implementation lets us scope the gate precisely.
+ */
+
+export type PlayerHqV2TabKey = "heroi" | "arsenal" | "diario" | "mapa";
+
+export interface PlayerHqKeyboardShortcutsProps {
+  onTabChange: (tab: PlayerHqV2TabKey) => void;
+  /** When false, listener is detached. Defaults to true. */
+  enabled?: boolean;
+}
+
+const TAB_BY_KEY: Record<string, PlayerHqV2TabKey> = {
+  "1": "heroi",
+  "2": "arsenal",
+  "3": "diario",
+  "4": "mapa",
+};
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName.toLowerCase();
+  if (tag === "input" || tag === "textarea" || tag === "select") return true;
+  if (target.isContentEditable) return true;
+  if (target.closest(".ProseMirror")) return true;
+  return false;
+}
+
+export function PlayerHqKeyboardShortcuts({
+  onTabChange,
+  enabled = true,
+}: PlayerHqKeyboardShortcutsProps) {
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  const closeHelp = useCallback(() => setHelpOpen(false), []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (isEditableTarget(e.target)) return;
+      // Ignore when modifier keys are pressed (so Ctrl+1 etc. still
+      // route to the browser).
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      if (e.key === "?") {
+        e.preventDefault();
+        setHelpOpen((prev) => !prev);
+        return;
+      }
+
+      const tab = TAB_BY_KEY[e.key];
+      if (tab) {
+        e.preventDefault();
+        onTabChange(tab);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [enabled, onTabChange]);
+
+  return <KeyboardHelpOverlay open={helpOpen} onClose={closeHelp} />;
+}

--- a/components/player-hq/v2/PlayerHqKeyboardShortcuts.tsx
+++ b/components/player-hq/v2/PlayerHqKeyboardShortcuts.tsx
@@ -43,6 +43,11 @@ function isEditableTarget(target: EventTarget | null): boolean {
   if (tag === "input" || tag === "textarea" || tag === "select") return true;
   if (target.isContentEditable) return true;
   if (target.closest(".ProseMirror")) return true;
+  // Suppress shortcuts while a dialog/cmdk surface is open above the
+  // shell — e.g. CharacterEditSheet, command palette, the help overlay
+  // itself. Otherwise pressing `1` would silently flip the underlying
+  // tab while the user is interacting with the modal.
+  if (target.closest('[role="dialog"], [cmdk-root]')) return true;
   return false;
 }
 
@@ -58,6 +63,11 @@ export function PlayerHqKeyboardShortcuts({
     if (!enabled) return;
 
     function onKeyDown(e: KeyboardEvent) {
+      // IME composition: JP/CN/KR users typing `?` mid-composition
+      // would otherwise toggle the overlay. `keyCode === 229` is the
+      // legacy fallback when `isComposing` is false but composition is
+      // still active in older browsers.
+      if (e.isComposing || e.keyCode === 229) return;
       if (isEditableTarget(e.target)) return;
       // Ignore when modifier keys are pressed (so Ctrl+1 etc. still
       // route to the browser).

--- a/messages/en.json
+++ b/messages/en.json
@@ -1149,6 +1149,15 @@
       "abilities": "Abilities",
       "aria_tablist": "Character tabs"
     },
+    "keyboard": {
+      "title": "Keyboard shortcuts",
+      "tab1": "Go to Herói",
+      "tab2": "Go to Arsenal",
+      "tab3": "Go to Diário",
+      "tab4": "Go to Mapa",
+      "help": "Show shortcuts",
+      "close": "Close"
+    },
     "header": {
       "back_aria": "Back to campaign",
       "hd_label": "HD",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1149,6 +1149,15 @@
       "abilities": "Habilidades",
       "aria_tablist": "Abas do personagem"
     },
+    "keyboard": {
+      "title": "Atalhos do teclado",
+      "tab1": "Ir para Herói",
+      "tab2": "Ir para Arsenal",
+      "tab3": "Ir para Diário",
+      "tab4": "Ir para Mapa",
+      "help": "Mostrar atalhos",
+      "close": "Fechar"
+    },
     "header": {
       "back_aria": "Voltar para a campanha",
       "hd_label": "HD",


### PR DESCRIPTION
## Sprint 3 Track A · Story B5

Adds `PlayerHqKeyboardShortcuts` and `KeyboardHelpOverlay` to the v2
folder. Mounted ONLY by the V2 shell (Track B does the wiring after
B1 lands). Track A ships the surface.

**Spec:** [09-implementation-plan.md §B5](_bmad-output/party-mode-2026-04-22/09-implementation-plan.md) · [02-topologia-navegacao.md §🔗](_bmad-output/party-mode-2026-04-22/02-topologia-navegacao.md)

## Shortcuts
| Key | Action |
|---|---|
| `1` | Switch to Herói |
| `2` | Switch to Arsenal |
| `3` | Switch to Diário |
| `4` | Switch to Mapa |
| `?` | Toggle help overlay |
| `Esc` | Close help overlay |

## What changed
- `components/player-hq/v2/PlayerHqKeyboardShortcuts.tsx` — global keydown listener with input/contenteditable bypass + modifier-key bypass (so `Ctrl+1` etc. still routes to the browser).
- `components/player-hq/v2/KeyboardHelpOverlay.tsx` — accessible dialog (role=dialog, aria-modal, focused on open). Closes on Esc, backdrop click, or close button.
- `messages/{en,pt-BR}.json` — added `player_hq.keyboard.*` keys (title, `tab1..tab4`, help, close). Tab labels stay PT-BR (Herói/Arsenal/Diário/Mapa) per glossário ubíquo.

## AC checklist
- [x] Pressing `2` from any tab activates Arsenal (via `onTabChange` prop).
- [x] `?` opens overlay listing shortcuts (i18n keys: `keyboard.tab1` etc.).
- [x] Ignored when typing in input/textarea/select/contenteditable/ProseMirror.
- [x] Ignored when modifier keys (Ctrl/Meta/Alt) are held.
- [x] No conflict with existing global shortcuts (verified via grep — no other handler binds 1/2/3/4/? as bare keys).

## Combat parity
N/A — Player HQ surface only, V2-flag-gated indirectly through shell mount path.

## Depends on
- #62 (B1) — `PlayerHqShellV2` exports the tab change callback the new component takes via props. This PR creates the shortcut surface as **standalone components**; coordinator can merge B1 first, then wire the mount in a small follow-up (or merge these together and amend the shell mount during integration review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>