### PR TITLE
feat(grimório): B2a HeroiTab wraps the 8 Player HQ sections (EP-2)

### DIFF
--- a/components/player-hq/v2/HeroiTab.tsx
+++ b/components/player-hq/v2/HeroiTab.tsx
@@ -15,8 +15,18 @@ import { ResourceTrackerList } from "../ResourceTrackerList";
 import { SpellListSection } from "../SpellListSection";
 import { RestResetPanel } from "../RestResetPanel";
 
-export interface HeroiTabProps {
+/**
+ * Canonical prop shape forwarded by `PlayerHqShellV2` to every B2 tab
+ * wrapper. Locked in B1 so all 4 wrappers (Heroi/Arsenal/Diario/Mapa)
+ * share one signature — see `_bmad-output/party-mode-2026-04-22/
+ * 09-implementation-plan.md` §B1/§B2 and the PR #62 follow-up. Sibling
+ * wrappers `import type { PlayerHqV2TabProps } from "./HeroiTab"` to
+ * avoid forking the contract.
+ */
+export interface PlayerHqV2TabProps {
   characterId: string;
+  campaignId: string;
+  userId: string;
 }
 
 /**
@@ -48,7 +58,15 @@ export interface HeroiTabProps {
  * into HeroiTab is deferred until the `feat/estabilidade-combate` sprint
  * completes — combat-stability owns the `combat:ended` broadcast wiring.
  */
-export function HeroiTab({ characterId }: HeroiTabProps) {
+export function HeroiTab({
+  characterId,
+  // campaignId/userId arrive from the shell for parity with sibling
+  // wrappers, but Herói currently composes only character-scoped data.
+  // Keeping them in the destructure (prefixed) silences unused-prop
+  // drift if ever a section here grows to need them.
+  campaignId: _campaignId,
+  userId: _userId,
+}: PlayerHqV2TabProps) {
   const t = useTranslations("player_hq");
 
   const {

--- a/components/player-hq/v2/HeroiTab.tsx
+++ b/components/player-hq/v2/HeroiTab.tsx
@@ -1,23 +1,210 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { useCharacterStatus } from "@/lib/hooks/useCharacterStatus";
+import { useResourceTrackers } from "@/lib/hooks/useResourceTrackers";
+import { useCharacterAbilities } from "@/lib/hooks/useCharacterAbilities";
+import { useActiveEffects } from "@/lib/hooks/useActiveEffects";
+
+import { CharacterStatusPanel } from "../CharacterStatusPanel";
+import { CharacterCoreStats } from "../CharacterCoreStats";
+import { ProficienciesSection } from "../ProficienciesSection";
+import { ActiveEffectsPanel } from "../ActiveEffectsPanel";
+import { SpellSlotsHq } from "../SpellSlotsHq";
+import { ResourceTrackerList } from "../ResourceTrackerList";
+import { SpellListSection } from "../SpellListSection";
+import { RestResetPanel } from "../RestResetPanel";
+
+export interface HeroiTabProps {
+  characterId: string;
+}
 
 /**
- * HeroiTab — stub placeholder for Sprint 3 Track A (Story B1).
+ * HeroiTab — Sprint 3 Track B · Story B2a.
  *
- * Track B fills this with the composition of:
- *   CharacterStatusPanel + CharacterCoreStats + ProficienciesSection +
- *   ActiveEffectsPanel + SpellSlotsHq + ResourceTrackerList + SpellListSection
- * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ * Composes the 8 existing Player HQ sections that make up the "ficha viva"
+ * per [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md)
+ * + [03-wireframe-heroi.md](../../../_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md):
+ *
+ *   1. CharacterStatusPanel    — HP + conditions
+ *   2. CharacterCoreStats      — AC / Init / Speed / Inspiration / DC + 6 ability chips
+ *   3. ProficienciesSection    — saves + skills (3-col grid per A3)
+ *   4. ActiveEffectsPanel      — buffs / debuffs with concentration tracking
+ *   5. SpellSlotsHq            — slots I-IX with dot toggles
+ *   6. ResourceTrackerList     — class resources (Channel Divinity, Bardic etc.)
+ *   7. SpellListSection        — known/prepared spells
+ *   8. RestResetPanel          — short/long rest reset orchestrator
+ *
+ * Internal layout: single-column for now. The 2-column desktop layout
+ * (decision #29) lands in Wave 3 / Story C3 — keeping single-col here
+ * means C3 only has to swap the wrapper, not refactor data plumbing.
+ *
+ * Hooks called locally so the wrapper is self-contained — PlayerHqShellV2
+ * does not need to plumb hook results through props (mirrors V1's pattern
+ * where data fetching lives at the shell level but each section accepts
+ * primitive values).
+ *
+ * NOTE: PostCombatBanner is intentionally NOT mounted here. Its host move
+ * into HeroiTab is deferred until the `feat/estabilidade-combate` sprint
+ * completes — combat-stability owns the `combat:ended` broadcast wiring.
  */
-export function HeroiTab() {
+export function HeroiTab({ characterId }: HeroiTabProps) {
   const t = useTranslations("player_hq");
+
+  const {
+    character,
+    loading: charLoading,
+    updateHp,
+    updateTempHp,
+    toggleCondition,
+    setConditions,
+    toggleInspiration,
+    updateSpellSlots,
+    saveField,
+  } = useCharacterStatus(characterId);
+
+  // Single instance per hook — RestResetPanel + ResourceTrackerList share
+  // the same `useResourceTrackers` view (matches V1 PlayerHqShell.tsx:252
+  // "C-01 fix: Single instance of useResourceTrackers, shared by ...").
+  const resourceHook = useResourceTrackers(characterId);
+  const activeEffectsHook = useActiveEffects(characterId);
+  // Abilities live in Arsenal but RestResetPanel must reset their cooldowns
+  // too. ArsenalTab calls `useCharacterAbilities` independently for its own
+  // list rendering. The two instances cost an extra Supabase fetch but
+  // mirrors V1 PlayerHqShell.tsx:276 which also held the hook at shell
+  // level for the same purpose. A future shell-level lift can dedupe.
+  const abilitiesHook = useCharacterAbilities(characterId);
+
+  const loading = charLoading || resourceHook.loading;
+
+  if (loading) {
+    return (
+      <div
+        className="space-y-3 animate-pulse"
+        data-testid="heroi-tab-loading"
+      >
+        <div className="h-8 bg-white/5 rounded w-1/3" />
+        <div className="h-40 bg-white/5 rounded-xl" />
+        <div className="h-32 bg-white/5 rounded-xl" />
+      </div>
+    );
+  }
+
+  if (!character) {
+    return (
+      <div
+        className="text-center py-12"
+        data-testid="heroi-tab-empty"
+      >
+        <p className="text-muted-foreground">{t("sheet.no_character")}</p>
+      </div>
+    );
+  }
+
+  const concentrationConflict =
+    activeEffectsHook.getConcentrationConflict();
+
   return (
-    <div
-      data-testid="tab-stub-heroi"
-      className="rounded-xl border border-dashed border-border bg-card/40 p-6 text-center text-sm text-muted-foreground"
-    >
-      {t("tabs.heroi")}
+    <div className="space-y-3" data-testid="heroi-tab-content">
+      {/* TODO(post-combat): mount PostCombatBanner here once combat-
+          stability sprint completes wiring of the combat:ended broadcast
+          into Player HQ. See `lib/hooks/usePostCombatState.ts` for the
+          existing hook surface. */}
+
+      {/* 1. HP + Conditions */}
+      <CharacterStatusPanel
+        currentHp={character.current_hp}
+        maxHp={character.max_hp}
+        hpTemp={character.hp_temp}
+        conditions={character.conditions}
+        characterId={character.id}
+        characterName={character.name}
+        onHpChange={updateHp}
+        onTempHpChange={updateTempHp}
+        onToggleCondition={toggleCondition}
+        onSetConditions={setConditions}
+      />
+
+      {/* 2. AC / Init / Speed / Inspiration / Spell Save DC + 6 ability chips */}
+      <CharacterCoreStats
+        ac={character.ac}
+        initiativeBonus={character.initiative_bonus}
+        speed={character.speed}
+        inspiration={character.inspiration}
+        spellSaveDc={character.spell_save_dc}
+        str={character.str}
+        dex={character.dex}
+        con={character.con}
+        intScore={character.int_score}
+        wis={character.wis}
+        chaScore={character.cha_score}
+        onToggleInspiration={toggleInspiration}
+      />
+
+      {/* 3. Saves + Skills (3-col grid per A3) */}
+      <ProficienciesSection
+        proficiencies={character.proficiencies ?? {}}
+        level={character.level}
+        str={character.str}
+        dex={character.dex}
+        con={character.con}
+        intScore={character.int_score}
+        wis={character.wis}
+        chaScore={character.cha_score}
+        onSave={saveField}
+      />
+
+      {/* 4. Active Effects (buffs/debuffs + concentration) */}
+      <ActiveEffectsPanel
+        effects={activeEffectsHook.effects}
+        loading={activeEffectsHook.loading}
+        onAdd={activeEffectsHook.addEffect}
+        onUpdate={activeEffectsHook.updateEffect}
+        onDismiss={activeEffectsHook.dismissEffect}
+        onDecrementQuantity={activeEffectsHook.decrementQuantity}
+        onIncrementQuantity={activeEffectsHook.incrementQuantity}
+        concentrationConflictName={concentrationConflict?.name}
+        onDismissConcentration={
+          concentrationConflict
+            ? () => activeEffectsHook.dismissEffect(concentrationConflict.id)
+            : undefined
+        }
+      />
+
+      {/* 5. Spell Slots */}
+      <SpellSlotsHq
+        spellSlots={character.spell_slots}
+        onUpdateSpellSlots={updateSpellSlots}
+      />
+
+      {/* 6. Class Resources */}
+      <ResourceTrackerList
+        trackers={resourceHook.trackers}
+        loading={resourceHook.loading}
+        onToggleDot={resourceHook.toggleDot}
+        onResetTracker={resourceHook.resetTracker}
+        onAddTracker={resourceHook.addTracker}
+        onUpdateTracker={resourceHook.updateTracker}
+        onDeleteTracker={resourceHook.deleteTracker}
+      />
+
+      {/* 7. Spell List (search + filter + favorites) */}
+      <SpellListSection characterId={characterId} />
+
+      {/* 8. Rest / Reset orchestrator. Renders LAST so the rest button is
+          adjacent to the resources it affects when scrolling on mobile.
+          On V1 this lived at the TOP of the resources tab; placing it
+          last here matches the wireframe's intent of "end-of-day" action. */}
+      <RestResetPanel
+        resetByType={resourceHook.resetByType}
+        countByResetType={resourceHook.countByResetType}
+        spellSlots={character.spell_slots}
+        onSpellSlotsReset={updateSpellSlots}
+        additionalResetByType={abilitiesHook.resetByType}
+        additionalCountByResetType={abilitiesHook.countByResetType}
+        onDismissAllEffects={activeEffectsHook.dismissAll}
+        activeEffectCount={activeEffectsHook.effects.length}
+      />
     </div>
   );
 }

--- a/components/player-hq/v2/PlayerHqShellV2.tsx
+++ b/components/player-hq/v2/PlayerHqShellV2.tsx
@@ -142,6 +142,7 @@ export function PlayerHqShellV2({
   characterId,
   campaignId,
   campaignName,
+  userId,
   playerHqTourCompleted = true,
   initialTab,
 }: PlayerHqShellV2Props) {
@@ -262,7 +263,18 @@ export function PlayerHqShellV2({
         aria-labelledby={`tab-v2-${activeTab}`}
         className="animate-in fade-in-0 duration-150"
       >
-        {activeTab === "heroi" && <HeroiTab characterId={characterId} />}
+        {/* HeroiTab is wrapped in this PR — receives the canonical
+            PlayerHqV2TabProps shape (characterId + campaignId + userId).
+            Sibling tabs are still stubs without props in this branch;
+            #71/#72/#73 swap them in and add their own props as each
+            wrapper lands. */}
+        {activeTab === "heroi" && (
+          <HeroiTab
+            characterId={characterId}
+            campaignId={campaignId}
+            userId={userId}
+          />
+        )}
         {activeTab === "arsenal" && <ArsenalTab />}
         {activeTab === "diario" && <DiarioTab />}
         {activeTab === "mapa" && <MapaTab />}

--- a/components/player-hq/v2/PlayerHqShellV2.tsx
+++ b/components/player-hq/v2/PlayerHqShellV2.tsx
@@ -262,7 +262,7 @@ export function PlayerHqShellV2({
         aria-labelledby={`tab-v2-${activeTab}`}
         className="animate-in fade-in-0 duration-150"
       >
-        {activeTab === "heroi" && <HeroiTab />}
+        {activeTab === "heroi" && <HeroiTab characterId={characterId} />}
         {activeTab === "arsenal" && <ArsenalTab />}
         {activeTab === "diario" && <DiarioTab />}
         {activeTab === "mapa" && <MapaTab />}


### PR DESCRIPTION
## Summary

Sprint 3 Track B · Story B2a (3 pts).

Replaces the B1 HeroiTab stub with the real composition of the 8 existing Player HQ sections. **Composition only — no internal refactor of any wrapped component.**

> [!NOTE]
> **Base branch is \`feat/ep-2-b1-shell-4tabs\` (Track A's PR #62), not \`master\`.** Once #62 merges, GitHub will auto-rebase this onto master.

## What's wrapped

1. \`CharacterStatusPanel\`    — HP + conditions
2. \`CharacterCoreStats\`      — AC / Init / Speed / Inspiration / DC + 6 ability chips
3. \`ProficienciesSection\`    — saves + skills (3-col grid per A3)
4. \`ActiveEffectsPanel\`      — buffs/debuffs with concentration tracking
5. \`SpellSlotsHq\`            — slots I-IX with dot toggles
6. \`ResourceTrackerList\`     — class resources (Channel Divinity, Bardic, etc.)
7. \`SpellListSection\`        — known/prepared spells
8. \`RestResetPanel\`          — short/long rest reset orchestrator

## Hooks composed locally

- \`useCharacterStatus\`, \`useResourceTrackers\`, \`useActiveEffects\`, \`useCharacterAbilities\`
- Single instance of each per the V1 \"C-01 fix\" pattern (RestResetPanel + ResourceTrackerList share \`useResourceTrackers\`)
- \`useCharacterAbilities\` is called twice across V2 (here + ArsenalTab) — matches V1's pattern; a future shell-level lift can dedupe

## Layout

Single-column for now. The 2-column desktop layout (decision #29) lands in Wave 3 / Story C3 — keeping single-col here means C3 only swaps the wrapper, not refactor data plumbing.

## What this PR explicitly does NOT do

- **Does NOT mount \`PostCombatBanner\`.** Deferred until \`feat/estabilidade-combate\` completes the \`combat:ended\` broadcast wiring. A \`TODO(post-combat)\` comment marks the future host position.
- **Does NOT touch combat code or estabilidade-combate scope.** Hooks called are all read/persistence — none broadcast or mutate combat state.
- **Does NOT refactor any wrapped component.** Composition only, per B2 AC.

## Acceptance criteria

- [x] All 8 sections render with valid character data
- [x] \`data-testid=\"heroi-tab-content\"\` on root container
- [x] No regression in any wrapped component (zero internal changes)
- [x] \`rtk tsc --noEmit\` clean
- [x] \`rtk npm run lint\` zero errors in v2/ files

## Wireframe

[03-wireframe-heroi.md](https://github.com/danielroscoe-97/projeto-rpg/blob/master/_bmad-output/party-mode-2026-04-22/03-wireframe-heroi.md)

## Test plan

- [ ] Visual review against wireframe (UX label)
- [ ] Manual smoke: \`?tab=heroi\` renders all 8 sections in order
- [ ] HP +/- still updates DB (CharacterStatusPanel intact)
- [ ] Long rest still resets spell slots, abilities, trackers, effects
- [ ] Mobile 390 single-col still legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)