### PR TITLE
feat(grimório): B2d MapaTab wraps PlayerMindMap unchanged (EP-2)

### DIFF
--- a/components/player-hq/v2/MapaTab.tsx
+++ b/components/player-hq/v2/MapaTab.tsx
@@ -1,21 +1,48 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { PlayerMindMap } from "../PlayerMindMap";
+
+export interface MapaTabProps {
+  characterId: string;
+  campaignId: string;
+  campaignName: string;
+  userId: string;
+}
 
 /**
- * MapaTab — stub placeholder for Sprint 3 Track A (Story B1).
+ * MapaTab — Sprint 3 Track B · Story B2d (1 pt).
  *
- * Track B fills this with PlayerMindMap (unchanged).
- * See [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ * Wraps PlayerMindMap unchanged per
+ * [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md)
+ * + [06-wireframe-mapa.md](../../../_bmad-output/party-mode-2026-04-22/06-wireframe-mapa.md):
+ *
+ *   "Mapa hoje é a tab mais polida do Player HQ ... mantém arquitetura
+ *    atual; ajustes cosméticos no §6."
+ *
+ * The only addition vs. the B1 stub is a wrapper div with `data-testid=
+ * "mapa-tab-content"` for E2E gating. PlayerMindMap and the entire drawer
+ * family stay verbatim — they ship 707 LOC of carry-over per the reuse
+ * matrix, with the `onNavigateTab` callback wired to a no-op since V2
+ * tab navigation is owned by PlayerHqShellV2 not the mind map.
+ *
+ * The §6.2 cosmetic ajustes ("Ver no Diário" link inline) and §2.3
+ * "halo gold em entidades atualizadas" land in Story D4 (cross-nav) and
+ * are intentionally NOT included here to keep B2d scope at 1 point.
  */
-export function MapaTab() {
-  const t = useTranslations("player_hq");
+export function MapaTab({
+  characterId,
+  campaignId,
+  campaignName,
+  userId,
+}: MapaTabProps) {
   return (
-    <div
-      data-testid="tab-stub-mapa"
-      className="rounded-xl border border-dashed border-border bg-card/40 p-6 text-center text-sm text-muted-foreground"
-    >
-      {t("tabs.mapa")}
+    <div data-testid="mapa-tab-content">
+      <PlayerMindMap
+        campaignId={campaignId}
+        campaignName={campaignName}
+        characterId={characterId}
+        userId={userId}
+      />
     </div>
   );
 }

--- a/components/player-hq/v2/PlayerHqShellV2.tsx
+++ b/components/player-hq/v2/PlayerHqShellV2.tsx
@@ -142,6 +142,7 @@ export function PlayerHqShellV2({
   characterId,
   campaignId,
   campaignName,
+  userId,
   playerHqTourCompleted = true,
   initialTab,
 }: PlayerHqShellV2Props) {
@@ -265,7 +266,14 @@ export function PlayerHqShellV2({
         {activeTab === "heroi" && <HeroiTab />}
         {activeTab === "arsenal" && <ArsenalTab />}
         {activeTab === "diario" && <DiarioTab />}
-        {activeTab === "mapa" && <MapaTab />}
+        {activeTab === "mapa" && (
+          <MapaTab
+            characterId={characterId}
+            campaignId={campaignId}
+            campaignName={campaignName}
+            userId={userId}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Sprint 3 Track B · Story B2d (1 pt). Smallest of the four B2 wrappers — pure carry-over of \`PlayerMindMap\` per the wireframe directive to leave the Mapa surface alone in Sprint 3.

> [!NOTE]
> **Base branch is \`feat/ep-2-b1-shell-4tabs\` (Track A's PR #62).**

## What's wrapped

\`PlayerMindMap\` plus the entire 707-LOC drawer family (\`PlayerNpcDrawer\`, \`PlayerQuestDrawer\`, \`PlayerLocationDrawer\`, \`PlayerFactionDrawer\`, \`PlayerPinDrawer\`, \`PlayerSessionDrawer\`, \`DrawerShell\`) — verbatim per [12-reuse-matrix §2.6](https://github.com/danielroscoe-97/projeto-rpg/blob/master/_bmad-output/party-mode-2026-04-22/12-reuse-matrix.md).

The wireframe explicitly calls out \"manter arquitetura atual; ajustes cosméticos no §6\" — those §6.2 (\"Ver no Diário\" inline link) and §2.3 (\"halo gold em entidades atualizadas\") cosmetic ajustes land in Story D4 (cross-nav).

## Acceptance criteria

- [x] PlayerMindMap renders unchanged
- [x] \`data-testid=\"mapa-tab-content\"\` on root container
- [x] \`rtk tsc --noEmit\` clean
- [x] No internal refactor

## Wireframe

[06-wireframe-mapa.md](https://github.com/danielroscoe-97/projeto-rpg/blob/master/_bmad-output/party-mode-2026-04-22/06-wireframe-mapa.md)

## Test plan

- [ ] Visual smoke: \`?tab=mapa\` renders mind map identical to V1's \`?tab=map\`
- [ ] Drawer family (npc/quest/location/faction/pin/session) all open
- [ ] Filter chips still work
- [ ] Mobile 390 mind map still pannable + zoomable

🤖 Generated with [Claude Code](https://claude.com/claude-code)