### PR TITLE
feat(grimório): B2d MapaTab wraps PlayerMindMap unchanged (EP-2) [reopened]

### DIFF
--- a/components/player-hq/v2/MapaTab.tsx
+++ b/components/player-hq/v2/MapaTab.tsx
@@ -1,22 +1,52 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { PlayerMindMap } from "../PlayerMindMap";
 import type { PlayerHqV2TabProps } from "./HeroiTab";
 
 /**
- * MapaTab — stub placeholder for Sprint 3 Track A (Story B1).
- *
- * Track B fills this with PlayerMindMap (unchanged).
- * See [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md).
+ * Mapa needs `campaignName` for PlayerMindMap, which is not part of the
+ * canonical PlayerHqV2TabProps shape. Extend instead of forking — the
+ * shared base remains the canonical contract; Mapa adds the one extra
+ * field it needs.
  */
-export function MapaTab(_props: PlayerHqV2TabProps) {
-  const t = useTranslations("player_hq");
+export interface MapaTabProps extends PlayerHqV2TabProps {
+  campaignName: string;
+}
+
+/**
+ * MapaTab — Sprint 3 Track B · Story B2d (1 pt).
+ *
+ * Wraps PlayerMindMap unchanged per
+ * [09-implementation-plan.md §B2](../../../_bmad-output/party-mode-2026-04-22/09-implementation-plan.md)
+ * + [06-wireframe-mapa.md](../../../_bmad-output/party-mode-2026-04-22/06-wireframe-mapa.md):
+ *
+ *   "Mapa hoje é a tab mais polida do Player HQ ... mantém arquitetura
+ *    atual; ajustes cosméticos no §6."
+ *
+ * The only addition vs. the B1 stub is a wrapper div with `data-testid=
+ * "mapa-tab-content"` for E2E gating. PlayerMindMap and the entire drawer
+ * family stay verbatim — they ship 707 LOC of carry-over per the reuse
+ * matrix, with the `onNavigateTab` callback wired to a no-op since V2
+ * tab navigation is owned by PlayerHqShellV2 not the mind map.
+ *
+ * The §6.2 cosmetic ajustes ("Ver no Diário" link inline) and §2.3
+ * "halo gold em entidades atualizadas" land in Story D4 (cross-nav) and
+ * are intentionally NOT included here to keep B2d scope at 1 point.
+ */
+export function MapaTab({
+  characterId,
+  campaignId,
+  campaignName,
+  userId,
+}: MapaTabProps) {
   return (
-    <div
-      data-testid="tab-stub-mapa"
-      className="rounded-xl border border-dashed border-border bg-card/40 p-6 text-center text-sm text-muted-foreground"
-    >
-      {t("tabs.mapa")}
+    <div data-testid="mapa-tab-content">
+      <PlayerMindMap
+        campaignId={campaignId}
+        campaignName={campaignName}
+        characterId={characterId}
+        userId={userId}
+      />
     </div>
   );
 }

--- a/components/player-hq/v2/PlayerHqShellV2.tsx
+++ b/components/player-hq/v2/PlayerHqShellV2.tsx
@@ -263,11 +263,9 @@ export function PlayerHqShellV2({
         aria-labelledby={`tab-v2-${activeTab}`}
         className="animate-in fade-in-0 duration-150"
       >
-        {/* All 4 tabs receive the canonical PlayerHqV2TabProps shape.
-            HeroiTab is the real wrapper from this PR (B2a); siblings
-            are still stubs from #62 follow-up (they accept the full
-            shape and ignore via `_` prefix). #71/#72/#73 each swap
-            their stub for a real wrapper that consumes what it needs. */}
+        {/* All 4 tabs receive PlayerHqV2TabProps. HeroiTab/ArsenalTab/
+            DiarioTab are real wrappers (merged in earlier B2 PRs); MapaTab
+            additionally needs `campaignName` per its extended interface. */}
         {activeTab === "heroi" && (
           <HeroiTab
             characterId={characterId}
@@ -293,6 +291,7 @@ export function PlayerHqShellV2({
           <MapaTab
             characterId={characterId}
             campaignId={campaignId}
+            campaignName={campaignName}
             userId={userId}
           />
         )}


### PR DESCRIPTION
**Reopened from #73** — auto-closed when base branch was deleted on B1 squash. Rebased on master with conflicts resolved.

## Sprint 3 Track B · Story B2d

Wraps PlayerMindMap unchanged — only adds `data-testid="mapa-tab-content"` for E2E gating + extends canonical `PlayerHqV2TabProps` with `campaignName` (which PlayerMindMap requires).

**Prop contract:** `MapaTabProps extends PlayerHqV2TabProps` — adds 1 field instead of forking the canonical interface.

**Combat parity:** Auth-only.

<!-- parity-intent
guest: n/a (Guest mode runs on /try, never reaches /sheet)
anon: n/a (Anon mode runs on /join/[token], never reaches /sheet)
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>